### PR TITLE
Taskmanager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'me.kosinkadink'
-version '0.1.0'
+version '0.2.0'
 
 test {
     useJUnitPlatform()

--- a/src/main/java/me/kosinkadink/performantplants/Main.java
+++ b/src/main/java/me/kosinkadink/performantplants/Main.java
@@ -96,6 +96,7 @@ public class Main extends JavaPlugin {
         pluginManager.registerEvents(new PlantBlockEventListener(this), this);
         pluginManager.registerEvents(new RecipeEventListener(this), this);
         pluginManager.registerEvents(new VanillaDropListener(this), this);
+        pluginManager.registerEvents(new HookListener(this), this);
     }
 
     private void registerCommands() {

--- a/src/main/java/me/kosinkadink/performantplants/Main.java
+++ b/src/main/java/me/kosinkadink/performantplants/Main.java
@@ -24,6 +24,7 @@ public class Main extends JavaPlugin {
     private StatisticsManager statisticsManager;
     private RecipeManager recipeManager;
     private VanillaDropManager vanillaDropManager;
+    private TaskManager taskManager;
 
     @Override
     public void onEnable() {
@@ -82,6 +83,7 @@ public class Main extends JavaPlugin {
         plantTypeManager = new PlantTypeManager(this);
         recipeManager = new RecipeManager(this);
         vanillaDropManager = new VanillaDropManager(this);
+        taskManager = new TaskManager(this);
         configManager = new ConfigurationManager(this);
         statisticsManager = new StatisticsManager(this);
         databaseManager = new DatabaseManager(this);
@@ -163,5 +165,9 @@ public class Main extends JavaPlugin {
 
     public VanillaDropManager getVanillaDropManager() {
         return vanillaDropManager;
+    }
+
+    public TaskManager getTaskManager() {
+        return taskManager;
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/PerformantPlants.java
+++ b/src/main/java/me/kosinkadink/performantplants/PerformantPlants.java
@@ -10,8 +10,8 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class Main extends JavaPlugin {
-    private static Main main;
+public class PerformantPlants extends JavaPlugin {
+    private static PerformantPlants performantPlants;
 
     private Economy economy;
 
@@ -28,7 +28,7 @@ public class Main extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        main = this;
+        performantPlants = this;
         setupEconomy();
         registerManagers();
         registerListeners();
@@ -61,8 +61,8 @@ public class Main extends JavaPlugin {
         registerCommands();
     }
 
-    public static Main getInstance() {
-        return main;
+    public static PerformantPlants getInstance() {
+        return performantPlants;
     }
 
     private void setupEconomy() {

--- a/src/main/java/me/kosinkadink/performantplants/PerformantPlants.java
+++ b/src/main/java/me/kosinkadink/performantplants/PerformantPlants.java
@@ -46,6 +46,7 @@ public class PerformantPlants extends JavaPlugin {
     public void onDisable() {
         plantManager.unloadAll(); // unload all plant chunks, pausing any growth tasks
         configManager.getConfigSettings().setDebug(true); // enable debug mode to get extra logging on shutdown
+        taskManager.freezeAllTasks(); // freeze tasks so that they can be properly saved in the db
         databaseManager.cancelTask(); // cancel queued up save task, to prevent possible double-run
         databaseManager.saveDatabases(); // save all plant blocks
     }

--- a/src/main/java/me/kosinkadink/performantplants/chunks/PlantChunk.java
+++ b/src/main/java/me/kosinkadink/performantplants/chunks/PlantChunk.java
@@ -1,11 +1,10 @@
 package me.kosinkadink.performantplants.chunks;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.locations.BlockLocation;
 import me.kosinkadink.performantplants.locations.ChunkLocation;
 
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PlantChunk {
@@ -66,17 +65,17 @@ public class PlantChunk {
         return location.getChunk().isLoaded();
     }
 
-    public void load(Main main) {
+    public void load(PerformantPlants performantPlants) {
         // start up task for each plantBlock
-        plantBlocks.forEach((blockLocation, plantBlock) -> main.getPlantManager().startGrowthTask(plantBlock));
+        plantBlocks.forEach((blockLocation, plantBlock) -> performantPlants.getPlantManager().startGrowthTask(plantBlock));
         loaded = true;
         // mark as loaded since save
         loadedSinceSave = true;
     }
 
-    public void unload(Main main) {
+    public void unload(PerformantPlants performantPlants) {
         // pause task for each plantBlock
-        plantBlocks.forEach((blockLocation, plantBlock) -> main.getPlantManager().pauseGrowthTask(plantBlock));
+        plantBlocks.forEach((blockLocation, plantBlock) -> performantPlants.getPlantManager().pauseGrowthTask(plantBlock));
         loaded = false;
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantBuyCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantBuyCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.PlantItem;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -8,34 +8,33 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class PlantBuyCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantBuyCommand(Main mainClass) {
+    public PlantBuyCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "buy" },
                 "Buy plant item for player.",
                 "/pp buy <player> <plant-id> <amount>",
                 "performantplants.buy",
                 2,
                 3);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         // get player
         String playerName = argList.get(0);
-        Player player = main.getServer().getPlayer(playerName);
+        Player player = performantPlants.getServer().getPlayer(playerName);
         if (player == null) {
             commandSender.sendMessage("Player " + playerName + " not found");
             return;
         }
         String plantId = argList.get(1);
         // get plant item
-        PlantItem requestedItem = main.getPlantTypeManager().getPlantItemById(plantId);
+        PlantItem requestedItem = performantPlants.getPlantTypeManager().getPlantItemById(plantId);
         // if item not found, inform sender and stop
         if (requestedItem == null) {
             commandSender.sendMessage(String.format("Plant item '%s' not recognized", plantId));
@@ -63,7 +62,7 @@ public class PlantBuyCommand extends PPCommand {
         }
         // check if player has necessary funds
         double totalWorth = requestedItem.getBuyPrice()*amount;
-        if (!main.getEconomy().has(player, totalWorth)) {
+        if (!performantPlants.getEconomy().has(player, totalWorth)) {
             commandSender.sendMessage(String.format("Player %s does not have the required %.2f to purchase %d of %s",
                     playerName, totalWorth, amount, plantId));
             return;
@@ -79,7 +78,7 @@ public class PlantBuyCommand extends PPCommand {
         }
         // take proper amount of money
         totalWorth = requestedItem.getBuyPrice()*givenAmount;
-        main.getEconomy().withdrawPlayer(player, totalWorth);
+        performantPlants.getEconomy().withdrawPlayer(player, totalWorth);
         // show message to buyer
         if (amount != 0 && givenAmount == 0) {
             player.sendMessage("Bought 0 of " + plantId + " due to full inventory");

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantChunksCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantChunksCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.chunks.PlantChunk;
 import me.kosinkadink.performantplants.locations.ChunkLocation;
 import me.kosinkadink.performantplants.storage.PlantChunkStorage;
@@ -11,21 +11,21 @@ import java.util.Map;
 
 public class PlantChunksCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantChunksCommand(Main mainClass) {
+    public PlantChunksCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "chunks" },
                 "Returns total amount of plant chunks in world.",
                 "/pp chunks",
                 "performantplants.chunks",
                 0,
                 0);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
-        for (Map.Entry<String, PlantChunkStorage> storageMap : main.getPlantManager().getPlantChunkStorageMap().entrySet()) {
+        for (Map.Entry<String, PlantChunkStorage> storageMap : performantPlants.getPlantManager().getPlantChunkStorageMap().entrySet()) {
             int loadedCount = 0;
             int unloadedCount = 0;
             PlantChunkStorage storage = storageMap.getValue();

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantGiveCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantGiveCommand.java
@@ -1,40 +1,39 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class PlantGiveCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantGiveCommand(Main mainClass) {
+    public PlantGiveCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "give" },
                 "Give plant item to player.",
                 "/pp give <player> <plant-id> <amount>",
                 "performantplants.give",
                 2,
                 3);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         // get player
         String playerName = argList.get(0);
-        Player player = main.getServer().getPlayer(playerName);
+        Player player = performantPlants.getServer().getPlayer(playerName);
         if (player == null) {
             commandSender.sendMessage("Player " + playerName + " not found");
             return;
         }
         String plantId = argList.get(1);
         // get plant item
-        ItemStack requestedItem = main.getPlantTypeManager().getPlantItemStackById(plantId);
+        ItemStack requestedItem = performantPlants.getPlantTypeManager().getPlantItemStackById(plantId);
         // if item not found, inform sender and stop
         if (requestedItem == null) {
             commandSender.sendMessage(String.format("Plant item '%s' not recognized", plantId));

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantHelpCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantHelpCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -9,23 +9,23 @@ import java.util.List;
 
 public class PlantHelpCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantHelpCommand(Main mainClass) {
+    public PlantHelpCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "help" },
                 "List usage and descriptions for available commands.",
                 "/pp help",
                 "performantplants.help",
                 0,
                 0);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         commandSender.sendMessage(String.format("%s ----%s PerformantPlants Help%s ----",
                 ChatColor.AQUA, ChatColor.GREEN, ChatColor.AQUA));
-        for (PPCommand command : main.getCommandManager().getRegisteredCommands()) {
+        for (PPCommand command : performantPlants.getCommandManager().getRegisteredCommands()) {
             if (commandSender instanceof Player) {
                 // if player does not have permission to use command, don't list it
                 if (!commandSender.hasPermission(command.getPermission())) {

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantInfoCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantInfoCommand.java
@@ -1,32 +1,30 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.clip.placeholderapi.PlaceholderAPI;
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.Plant;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 import java.util.List;
 
 public class PlantInfoCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantInfoCommand(Main mainClass) {
+    public PlantInfoCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "info" },
                 "Show plant info.",
                 "/pp info <plant-id>",
                 "performantplants.info",
                 1,
                 1);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         String plantId = argList.get(0);
         // get plant
-        Plant plant = main.getPlantTypeManager().getPlantById(plantId);
+        Plant plant = performantPlants.getPlantTypeManager().getPlantById(plantId);
         if (plant == null) {
             commandSender.sendMessage(String.format("Plant '%s' not recognized", plantId));
             return;

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantPermsCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantPermsCommand.java
@@ -1,25 +1,24 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.util.PermissionHelper;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 import java.util.List;
 
 public class PlantPermsCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantPermsCommand(Main mainClass) {
+    public PlantPermsCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "perms" },
                 "List usage and permissions required for registered commands.",
                 "/pp perms",
                 "performantplants.perms",
                 0,
                 0);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
@@ -34,7 +33,7 @@ public class PlantPermsCommand extends PPCommand {
                 String.format("%sconsume: %s%s", ChatColor.GREEN, ChatColor.LIGHT_PURPLE, PermissionHelper.Consume),
         });
         commandSender.sendMessage(String.format("%sCommands:", ChatColor.AQUA));
-        for (PPCommand command : main.getCommandManager().getRegisteredCommands()) {
+        for (PPCommand command : performantPlants.getCommandManager().getRegisteredCommands()) {
             commandSender.sendMessage(String.format("%s%s %s- %s%s",
                     ChatColor.GREEN, command.getUsage(), ChatColor.AQUA,
                     ChatColor.LIGHT_PURPLE, command.getPermission()));

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantReloadCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantReloadCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -8,31 +8,31 @@ import java.util.List;
 
 public class PlantReloadCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantReloadCommand(Main mainClass) {
+    public PlantReloadCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "reload" },
                 "Reloads plant configs and all plant blocks.",
                 "/pp reload",
                 "performantplants.reload",
                 0,
                 0);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         // send start message
         String startMessage = "Reloading PerformantPlants, this might take a bit...";
-        main.getLogger().info(startMessage);
+        performantPlants.getLogger().info(startMessage);
         if (commandSender instanceof Player) {
             commandSender.sendMessage(startMessage);
         }
         // perform reload
-        main.manualReload();
+        performantPlants.manualReload();
         // send end message
         String endMessage = "PerformantPlants reload completed.";
-        main.getLogger().info(endMessage);
+        performantPlants.getLogger().info(endMessage);
         if (commandSender instanceof Player) {
             commandSender.sendMessage(endMessage);
         }

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantSellCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantSellCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.PlantItem;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -11,30 +11,30 @@ import java.util.List;
 
 public class PlantSellCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantSellCommand(Main mainClass) {
+    public PlantSellCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "sell" },
                 "Sell plant item for player.",
                 "/pp sell <player> <plant-id> <amount>",
                 "performantplants.sell",
                 2,
                 3);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         // get player
         String playerName = argList.get(0);
-        Player player = main.getServer().getPlayer(playerName);
+        Player player = performantPlants.getServer().getPlayer(playerName);
         if (player == null) {
             commandSender.sendMessage("Player " + playerName + " not found");
             return;
         }
         String plantId = argList.get(1);
         // get plant item
-        PlantItem requestedItem = main.getPlantTypeManager().getPlantItemById(plantId);
+        PlantItem requestedItem = performantPlants.getPlantTypeManager().getPlantItemById(plantId);
         // if item not found, inform sender and stop
         if (requestedItem == null) {
             commandSender.sendMessage(String.format("Plant item '%s' not recognized", plantId));
@@ -71,7 +71,7 @@ public class PlantSellCommand extends PPCommand {
         }
         // take proper amount of money
         double totalWorth = requestedItem.getSellPrice()*takenAmount;
-        main.getEconomy().depositPlayer(player, totalWorth);
+        performantPlants.getEconomy().depositPlayer(player, totalWorth);
         // show message to seller
         if (amount != 0 && takenAmount == 0) {
             player.sendMessage("Sold 0 of " + plantId + " due to none found in inventory");
@@ -86,7 +86,7 @@ public class PlantSellCommand extends PPCommand {
                         playerName, takenAmount, plantId, totalWorth));
             }
             // add sale to StatisticsManager
-            main.getStatisticsManager().addPlantItemsSold(player.getUniqueId(), plantId, takenAmount);
+            performantPlants.getStatisticsManager().addPlantItemsSold(player.getUniqueId(), plantId, takenAmount);
         }
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetAllPlayersCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetAllPlayersCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 
 import java.lang.reflect.InvocationTargetException;
@@ -10,25 +10,25 @@ import java.util.List;
 
 public class PlantStatsResetAllPlayersCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private HashMap<String, Method> statMethodMap = new HashMap<>();
 
-    public PlantStatsResetAllPlayersCommand(Main mainClass) {
+    public PlantStatsResetAllPlayersCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "stats", "resetallplayers" },
                 "Resets specific stat for all players.",
                 "/pp stats resetallplayers <stat>",
                 "performantplants.stats.resetallplayers",
                 1,
                 1);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
         fillInStatMethodMap();
     }
 
     void fillInStatMethodMap() {
         try {
             statMethodMap.put("sold",
-                    main.getStatisticsManager().getClass().getMethod("resetAllPlantItemsSoldForAllPlayers"));
+                    performantPlants.getStatisticsManager().getClass().getMethod("resetAllPlantItemsSoldForAllPlayers"));
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }
@@ -42,7 +42,7 @@ public class PlantStatsResetAllPlayersCommand extends PPCommand {
         Method method = statMethodMap.get(stat);
         if (method != null) {
             try {
-                method.invoke(main.getStatisticsManager());
+                method.invoke(performantPlants.getStatisticsManager());
                 commandSender.sendMessage(String.format("Stat '%s' reset for all players", stat));
             } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -13,25 +13,25 @@ import java.util.UUID;
 
 public class PlantStatsResetCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private HashMap<String, Method> statMethodMap = new HashMap<>();
 
-    public PlantStatsResetCommand(Main mainClass) {
+    public PlantStatsResetCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "stats", "reset" },
                 "Resets specific stat for specific players for specific plant-id.",
                 "/pp stats reset <stat> <player> <plant-id>",
                 "performantplants.stats.reset",
                 3,
                 3);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
         fillInStatMethodMap();
     }
 
     void fillInStatMethodMap() {
         try {
             statMethodMap.put("sold",
-                    main.getStatisticsManager().getClass().getMethod("resetPlantItemsSoldForPlayer", UUID.class, String.class));
+                    performantPlants.getStatisticsManager().getClass().getMethod("resetPlantItemsSoldForPlayer", UUID.class, String.class));
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }
@@ -47,11 +47,11 @@ public class PlantStatsResetCommand extends PPCommand {
         // get plantItemId
         String plantItemId = argList.get(2);
         // check if player is online
-        Player player = main.getServer().getPlayer(playerString);
+        Player player = performantPlants.getServer().getPlayer(playerString);
         if (player == null) {
             //get list of offline players, see if name matches
             boolean found = false;
-            for (OfflinePlayer offlinePlayer : main.getServer().getOfflinePlayers()) {
+            for (OfflinePlayer offlinePlayer : performantPlants.getServer().getOfflinePlayers()) {
                 if (playerString.equalsIgnoreCase(offlinePlayer.getName())
                         || playerString.equalsIgnoreCase(offlinePlayer.getUniqueId().toString())) {
                     playerUUID = offlinePlayer.getUniqueId();
@@ -70,7 +70,7 @@ public class PlantStatsResetCommand extends PPCommand {
         Method method = statMethodMap.get(stat);
         if (method != null) {
             try {
-                if ((boolean)method.invoke(main.getStatisticsManager(), playerUUID, plantItemId)) {
+                if ((boolean)method.invoke(performantPlants.getStatisticsManager(), playerUUID, plantItemId)) {
                     commandSender.sendMessage(String.format("Stat '%s' reset for player %s for plant item '%s'", stat, playerString, plantItemId));
                 } else {
                     commandSender.sendMessage(String.format("No stats found to reset for plant item %s", plantItemId));

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetPlayerCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantStatsResetPlayerCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -13,25 +13,25 @@ import java.util.UUID;
 
 public class PlantStatsResetPlayerCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private HashMap<String, Method> statMethodMap = new HashMap<>();
 
-    public PlantStatsResetPlayerCommand(Main mainClass) {
+    public PlantStatsResetPlayerCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "stats", "resetplayer" },
                 "Resets specific stat for specific players.",
                 "/pp stats resetplayer <stat> <player>",
                 "performantplants.stats.resetplayer",
                 2,
                 2);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
         fillInStatMethodMap();
     }
 
     void fillInStatMethodMap() {
         try {
             statMethodMap.put("sold",
-                    main.getStatisticsManager().getClass().getMethod("resetAllPlantItemsSoldForPlayer", UUID.class));
+                    performantPlants.getStatisticsManager().getClass().getMethod("resetAllPlantItemsSoldForPlayer", UUID.class));
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }
@@ -45,11 +45,11 @@ public class PlantStatsResetPlayerCommand extends PPCommand {
         String playerString = argList.get(1);
         UUID playerUUID = null;
         // check if player is online
-        Player player = main.getServer().getPlayer(playerString);
+        Player player = performantPlants.getServer().getPlayer(playerString);
         if (player == null) {
             //get list of offline players, see if name matches
             boolean found = false;
-            for (OfflinePlayer offlinePlayer : main.getServer().getOfflinePlayers()) {
+            for (OfflinePlayer offlinePlayer : performantPlants.getServer().getOfflinePlayers()) {
                 if (playerString.equalsIgnoreCase(offlinePlayer.getName())
                         || playerString.equalsIgnoreCase(offlinePlayer.getUniqueId().toString())) {
                     playerUUID = offlinePlayer.getUniqueId();
@@ -68,7 +68,7 @@ public class PlantStatsResetPlayerCommand extends PPCommand {
         Method method = statMethodMap.get(stat);
         if (method != null) {
             try {
-                method.invoke(main.getStatisticsManager(), playerUUID);
+                method.invoke(performantPlants.getStatisticsManager(), playerUUID);
                 commandSender.sendMessage(String.format("Stat '%s' reset for player %s", stat, playerString));
             } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagAddCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagAddCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.storage.StatisticsTagStorage;
 import org.bukkit.command.CommandSender;
 
@@ -9,16 +9,16 @@ import java.util.List;
 
 public class PlantTagAddCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagAddCommand(Main mainClass) {
+    public PlantTagAddCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "add" },
                 "Add plant ids to existing tag.",
                 "/pp tag add <tag-id> <plant-ids,comma,separated>",
                 "performantplants.tag.add",
                 2,
                 2);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
@@ -30,7 +30,7 @@ public class PlantTagAddCommand extends PPCommand {
             return;
         }
         // see if tag exists
-        StatisticsTagStorage storage = main.getStatisticsManager().getPlantTag(tagId);
+        StatisticsTagStorage storage = performantPlants.getStatisticsManager().getPlantTag(tagId);
         if (storage == null) {
             commandSender.sendMessage(String.format("Tag '%s' does not exist", tagId));
             return;
@@ -44,8 +44,8 @@ public class PlantTagAddCommand extends PPCommand {
         ArrayList<String> plantIdsAdded = new ArrayList<>();
         ArrayList<String> plantIdsNotAdded = new ArrayList<>();
         for (String plantId : plantIdList) {
-            if (main.getPlantTypeManager().getPlantById(plantId) != null) {
-                main.getStatisticsManager().addPlantId(tagId, plantId);
+            if (performantPlants.getPlantTypeManager().getPlantById(plantId) != null) {
+                performantPlants.getStatisticsManager().addPlantId(tagId, plantId);
                 plantIdsAdded.add(plantId);
             } else {
                 plantIdsNotAdded.add(plantId);

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagInfoCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagInfoCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.storage.StatisticsTagStorage;
 import org.bukkit.command.CommandSender;
 
@@ -8,22 +8,22 @@ import java.util.List;
 
 public class PlantTagInfoCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagInfoCommand(Main mainClass) {
+    public PlantTagInfoCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "info" },
                 "Show list of plant ids for specified tag.",
                 "/pp tag info <tag-id>",
                 "performantplants.tag.info",
                 1,
                 1);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         String tagId = argList.get(0);
-        StatisticsTagStorage storage = main.getStatisticsManager().getPlantTag(tagId);
+        StatisticsTagStorage storage = performantPlants.getStatisticsManager().getPlantTag(tagId);
         if (storage == null) {
             commandSender.sendMessage(String.format("Tag '%s' not recognized", tagId));
             return;

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagListCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagListCommand.java
@@ -1,30 +1,28 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
-import me.kosinkadink.performantplants.storage.StatisticsTagStorage;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class PlantTagListCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagListCommand(Main mainClass) {
+    public PlantTagListCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "list" },
                 "Show list of all registered tags.",
                 "/pp tag list",
                 "performantplants.tag.list",
                 0,
                 0);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
-        ArrayList<String> tags = main.getStatisticsManager().getAllPlantTags();
+        ArrayList<String> tags = performantPlants.getStatisticsManager().getAllPlantTags();
         if (tags.isEmpty()) {
             commandSender.sendMessage("No tags have been registered.");
             return;

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagRegisterCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagRegisterCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;
@@ -8,16 +8,16 @@ import java.util.List;
 
 public class PlantTagRegisterCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagRegisterCommand(Main mainClass) {
+    public PlantTagRegisterCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "register" },
                 "Register tag with initial plant ids; adds plant ids to existing tag if applicable.",
                 "/pp tag register <tag-id> <plant-ids,comma,separated>",
                 "performantplants.tag.register",
                 2,
                 2);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
@@ -37,8 +37,8 @@ public class PlantTagRegisterCommand extends PPCommand {
         ArrayList<String> plantIdsAdded = new ArrayList<>();
         ArrayList<String> plantIdsNotAdded = new ArrayList<>();
         for (String plantId : plantIdList) {
-            if (main.getPlantTypeManager().getPlantById(plantId) != null) {
-                main.getStatisticsManager().addPlantId(tagId, plantId, true);
+            if (performantPlants.getPlantTypeManager().getPlantById(plantId) != null) {
+                performantPlants.getStatisticsManager().addPlantId(tagId, plantId, true);
                 plantIdsAdded.add(plantId);
             } else {
                 plantIdsNotAdded.add(plantId);

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagRemoveCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagRemoveCommand.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.storage.StatisticsTagStorage;
 import org.bukkit.command.CommandSender;
 
@@ -9,16 +9,16 @@ import java.util.List;
 
 public class PlantTagRemoveCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagRemoveCommand(Main mainClass) {
+    public PlantTagRemoveCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "remove" },
                 "Removes plant ids from tag; unregisters tag if no plant ids remaining.",
                 "/pp tag remove <tag-id> <plant-ids,comma,separated>",
                 "performantplants.tag.remove",
                 2,
                 2);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
@@ -30,7 +30,7 @@ public class PlantTagRemoveCommand extends PPCommand {
             return;
         }
         // see if tag exists
-        StatisticsTagStorage storage = main.getStatisticsManager().getPlantTag(tagId);
+        StatisticsTagStorage storage = performantPlants.getStatisticsManager().getPlantTag(tagId);
         if (storage == null) {
             commandSender.sendMessage(String.format("Tag '%s' does not exist", tagId));
             return;
@@ -44,7 +44,7 @@ public class PlantTagRemoveCommand extends PPCommand {
         ArrayList<String> plantIdsRemoved = new ArrayList<>();
         ArrayList<String> plantIdsNotRemoved = new ArrayList<>();
         for (String plantId : plantIdList) {
-            if (main.getStatisticsManager().removePlantId(tagId, plantId) != null) {
+            if (performantPlants.getStatisticsManager().removePlantId(tagId, plantId) != null) {
                 plantIdsRemoved.add(plantId);
             } else {
                 plantIdsNotRemoved.add(plantId);
@@ -54,7 +54,7 @@ public class PlantTagRemoveCommand extends PPCommand {
             commandSender.sendMessage("None of the plant ids were found stored in the tag; none removed");
             return;
         }
-        boolean allRemoved = main.getStatisticsManager().getPlantTag(tagId) == null;
+        boolean allRemoved = performantPlants.getStatisticsManager().getPlantTag(tagId) == null;
         if (allRemoved) {
             commandSender.sendMessage("Successfully removed plant ids; no plant ids left in tag, tag is now unregistered");
             return;

--- a/src/main/java/me/kosinkadink/performantplants/commands/PlantTagUnregisterCommand.java
+++ b/src/main/java/me/kosinkadink/performantplants/commands/PlantTagUnregisterCommand.java
@@ -1,31 +1,29 @@
 package me.kosinkadink.performantplants.commands;
 
-import me.kosinkadink.performantplants.Main;
-import me.kosinkadink.performantplants.statistics.StatisticsTagItem;
-import me.kosinkadink.performantplants.storage.StatisticsTagStorage;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
 
 public class PlantTagUnregisterCommand extends PPCommand {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantTagUnregisterCommand(Main mainClass) {
+    public PlantTagUnregisterCommand(PerformantPlants performantPlantsClass) {
         super(new String[] { "tag", "unregister" },
                 "Unregister tag; cannot be undone.",
                 "/pp tag unregister <tag-id>",
                 "performantplants.tag.unregister",
                 1,
                 1);
-        main = mainClass;
+        performantPlants = performantPlantsClass;
     }
 
     @Override
     public void executeCommand(CommandSender commandSender, List<String> argList) {
         String tagId = argList.get(0);
         // see if registered
-        boolean removed = main.getStatisticsManager().unregisterPlantTag(tagId);
+        boolean removed = performantPlants.getStatisticsManager().unregisterPlantTag(tagId);
         if (!removed) {
             commandSender.sendMessage(String.format("Tag '%s' not found", tagId));
             return;

--- a/src/main/java/me/kosinkadink/performantplants/effects/PlantScriptEffect.java
+++ b/src/main/java/me/kosinkadink/performantplants/effects/PlantScriptEffect.java
@@ -1,0 +1,36 @@
+package me.kosinkadink.performantplants.effects;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+public class PlantScriptEffect extends PlantEffect {
+
+    private ScriptBlock scriptBlock = ScriptResult.EMPTY;
+
+    public PlantScriptEffect() { }
+
+    @Override
+    void performEffectAction(Player player, PlantBlock plantBlock) {
+        getScriptBlockValue(player, plantBlock);
+    }
+
+    @Override
+    void performEffectAction(Block block, PlantBlock plantBlock) {
+        getScriptBlockValue(null, plantBlock);
+    }
+
+    public ScriptBlock getScriptBlock() {
+        return scriptBlock;
+    }
+
+    public ScriptResult getScriptBlockValue(Player player, PlantBlock plantBlock) {
+        return scriptBlock.loadValue(plantBlock, player);
+    }
+
+    public void setScriptBlock(ScriptBlock scriptBlock) {
+        this.scriptBlock = scriptBlock;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/exceptions/PlantHookJsonParseException.java
+++ b/src/main/java/me/kosinkadink/performantplants/exceptions/PlantHookJsonParseException.java
@@ -1,0 +1,7 @@
+package me.kosinkadink.performantplants.exceptions;
+
+public class PlantHookJsonParseException extends Exception {
+    public PlantHookJsonParseException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/executors/PPCommandExecutor.java
+++ b/src/main/java/me/kosinkadink/performantplants/executors/PPCommandExecutor.java
@@ -65,7 +65,7 @@ public class PPCommandExecutor implements TabExecutor {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
 
         if (args.length == 1) {
-            List<PPCommand> subCommands = main.getCommandManager().getRegisteredCommands();
+            List<PPCommand> subCommands = performantPlants.getCommandManager().getRegisteredCommands();
             List<String> possibleSubCommands = new ArrayList<>();
             for (PPCommand subCommand : subCommands) {
                 subCommand.getCommandNameWords();

--- a/src/main/java/me/kosinkadink/performantplants/executors/PPCommandExecutor.java
+++ b/src/main/java/me/kosinkadink/performantplants/executors/PPCommandExecutor.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.executors;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.commands.PPCommand;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -11,10 +11,10 @@ import java.util.Arrays;
 
 public class PPCommandExecutor implements CommandExecutor {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PPCommandExecutor(Main mainClass) {
-        main = mainClass;
+    public PPCommandExecutor(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @Override
@@ -26,7 +26,7 @@ public class PPCommandExecutor implements CommandExecutor {
         }
         // find if args match a set of command words
         boolean matches;
-        for (PPCommand ppCommand : main.getCommandManager().getRegisteredCommands()) {
+        for (PPCommand ppCommand : performantPlants.getCommandManager().getRegisteredCommands()) {
             matches = true;
             // if command words are longer than args, go to next command
             if (ppCommand.getCommandNameWords().length > args.length) {

--- a/src/main/java/me/kosinkadink/performantplants/expansions/PerformantPlantExpansion.java
+++ b/src/main/java/me/kosinkadink/performantplants/expansions/PerformantPlantExpansion.java
@@ -2,7 +2,7 @@ package me.kosinkadink.performantplants.expansions;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.Plant;
 import me.kosinkadink.performantplants.plants.PlantItem;
 import me.kosinkadink.performantplants.statistics.StatisticsAmount;
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class PerformantPlantExpansion extends PlaceholderExpansion {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private final Pattern BUYPRICE_PATTERN = Pattern.compile("^buyprice_(?<plantItemId>[a-zA-Z0-9_.\\-]+)$");
     private final Pattern SELLPRICE_PATTERN = Pattern.compile("^sellprice_(?<plantItemId>[a-zA-Z0-9_.\\-]+)$");
@@ -24,8 +24,8 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
     private final Pattern SOLD_PATTERN = Pattern.compile("^sold_(?<playerUUID>[a-zA-Z0-9\\-]{36})_(?<plantItemId>[a-zA-Z0-9_.\\-]+)$");
     private final Pattern SOLDTAG_PATTERN = Pattern.compile("^soldtag_(?<playerUUID>[a-zA-Z0-9\\-]{36})_(?<plantTag>[a-zA-Z0-9_.\\-]+)$");
 
-    public PerformantPlantExpansion(Main main) {
-        this.main = main;
+    public PerformantPlantExpansion(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     /**
@@ -53,12 +53,12 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
 
     @Override
     public String getAuthor() {
-        return main.getDescription().getAuthors().toString();
+        return performantPlants.getDescription().getAuthors().toString();
     }
 
     @Override
     public String getVersion() {
-        return main.getDescription().getVersion();
+        return performantPlants.getDescription().getVersion();
     }
 
     @Override
@@ -76,7 +76,7 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
         Matcher matcher = BUYPRICE_PATTERN.matcher(identifier);
         if (matcher.find()) {
             String plantId = matcher.group("plantItemId");
-            PlantItem plantItem = main.getPlantTypeManager().getPlantItemById(plantId);
+            PlantItem plantItem = performantPlants.getPlantTypeManager().getPlantItemById(plantId);
             if (plantItem != null) {
                 return String.format("%.2f", plantItem.getBuyPrice());
             }
@@ -89,7 +89,7 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
         matcher = SELLPRICE_PATTERN.matcher(identifier);
         if (matcher.find()) {
             String plantId = matcher.group("plantItemId");
-            PlantItem plantItem = main.getPlantTypeManager().getPlantItemById(plantId);
+            PlantItem plantItem = performantPlants.getPlantTypeManager().getPlantItemById(plantId);
             if (plantItem != null) {
                 return String.format("%.2f", plantItem.getSellPrice());
             }
@@ -102,7 +102,7 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
         matcher = HASSEED_PATTERN.matcher(identifier);
         if (matcher.find()) {
             String plantId = matcher.group("plantId");
-            Plant plant = main.getPlantTypeManager().getPlantById(plantId);
+            Plant plant = performantPlants.getPlantTypeManager().getPlantById(plantId);
             if (plant != null) {
                 return String.format("%b", plant.hasSeed());
             }
@@ -117,7 +117,7 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
         if (matcher.find()) {
             String playerUUID = matcher.group("playerUUID");
             String plantId = matcher.group("plantItemId");
-            StatisticsAmount plantItemsSold = main.getStatisticsManager()
+            StatisticsAmount plantItemsSold = performantPlants.getStatisticsManager()
                     .getPlantItemsSold(UUID.fromString(playerUUID), plantId);
             int amount = 0;
             if (plantItemsSold != null) {
@@ -135,12 +135,12 @@ public class PerformantPlantExpansion extends PlaceholderExpansion {
             String playerUUID = matcher.group("playerUUID");
             String plantTag = matcher.group("plantTag");
             // get tag, if exists
-            StatisticsTagStorage storage = main.getStatisticsManager().getPlantTag(plantTag);
+            StatisticsTagStorage storage = performantPlants.getStatisticsManager().getPlantTag(plantTag);
             int amount = 0;
             if (storage != null) {
                 ArrayList<String> plantIds = storage.getAllPlantIds();
                 for (String plantId : plantIds) {
-                    StatisticsAmount plantItemsSold = main.getStatisticsManager()
+                    StatisticsAmount plantItemsSold = performantPlants.getStatisticsManager()
                             .getPlantItemsSold(UUID.fromString(playerUUID), plantId);
                     if (plantItemsSold != null) {
                         amount += plantItemsSold.getAmount();

--- a/src/main/java/me/kosinkadink/performantplants/hooks/HookAction.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/HookAction.java
@@ -1,0 +1,18 @@
+package me.kosinkadink.performantplants.hooks;
+
+public enum HookAction {
+    START, PAUSE, CANCEL;
+
+    public static HookAction fromString(String action) {
+        try {
+            return HookAction.valueOf(action);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public static String fromAction(HookAction action) {
+        return action.toString();
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/HookIdentifier.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/HookIdentifier.java
@@ -1,0 +1,52 @@
+package me.kosinkadink.performantplants.hooks;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class HookIdentifier {
+
+    private final String taskUUID;
+    private final String hookConfigId;
+
+    public HookIdentifier(String taskUUID, String hookConfigId) {
+        this.taskUUID = taskUUID;
+        this.hookConfigId = hookConfigId;
+    }
+
+    public HookIdentifier(UUID taskUUID, String hookConfigId) {
+        this.taskUUID = taskUUID.toString();
+        this.hookConfigId = hookConfigId;
+    }
+
+
+    public String getTaskUUID() {
+        return taskUUID;
+    }
+
+    public String getHookConfigId() {
+        return hookConfigId;
+    }
+
+    public boolean equals(Object o) {
+        // true if refers to this object
+        if (this == o) {
+            return true;
+        }
+        // false is object is null or not of same class
+        if (o == null || getClass() != o.getClass())
+            return false;
+        HookIdentifier fromO = (HookIdentifier)o;
+        // true if all components match, false otherwise
+        return taskUUID.equals(fromO.taskUUID) && hookConfigId.equals(fromO.hookConfigId);
+    }
+
+    public int hashCode() {
+        return Objects.hash(taskUUID, hookConfigId);
+    }
+
+    @Override
+    public String toString() {
+        return taskUUID + ',' + hookConfigId;
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
@@ -1,28 +1,21 @@
 package me.kosinkadink.performantplants.hooks;
 
 import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import me.kosinkadink.performantplants.tasks.PlantTask;
+import org.json.simple.JSONObject;
 
 import java.util.Objects;
 import java.util.UUID;
 
 public abstract class PlantHook {
 
-    protected final UUID hookId;
     protected final UUID taskId;
     protected final HookAction action;
 
     protected String hookConfigId = "";
 
-    public PlantHook(UUID hookId, UUID taskId, HookAction action, String hookConfigId) {
-        this.hookId = hookId;
-        this.taskId = taskId;
-        this.action = action;
-        this.hookConfigId = hookConfigId;
-    }
-
     public PlantHook(UUID taskId, HookAction action, String hookConfigId) {
-        hookId = UUID.randomUUID();
         this.taskId = taskId;
         this.action = action;
         this.hookConfigId = hookConfigId;
@@ -46,6 +39,10 @@ public abstract class PlantHook {
         }
         this.hookConfigId = hookConfigId;
     }
+
+    public abstract String createJsonString();
+
+    public abstract void loadValuesFromJsonString(String jsonString) throws PlantHookJsonParseException;
 
     public abstract boolean performScriptBlock(PlantTask task);
 
@@ -89,11 +86,11 @@ public abstract class PlantHook {
             return false;
         PlantHook fromO = (PlantHook)o;
         // true if hookId and taskId match
-        return hookId == fromO.hookId && taskId == fromO.taskId;
+        return taskId == fromO.taskId && hookConfigId.equals(fromO.hookConfigId);
     }
 
     public int hashCode() {
-        return Objects.hash(hookId, taskId);
+        return Objects.hash(taskId, hookConfigId);
     }
 
 }

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
@@ -1,0 +1,81 @@
+package me.kosinkadink.performantplants.hooks;
+
+import me.kosinkadink.performantplants.Main;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public abstract class PlantHook {
+
+    protected final UUID hookId;
+    protected final UUID taskId;
+    protected final HookAction action;
+
+    public PlantHook(UUID hookId, UUID taskId, HookAction action) {
+        this.hookId = hookId;
+        this.taskId = taskId;
+        this.action = action;
+    }
+
+    public PlantHook(UUID taskId, HookAction action) {
+        hookId = UUID.randomUUID();
+        this.taskId = taskId;
+        this.action = action;
+    }
+
+    public UUID getTaskId() {
+        return taskId;
+    }
+
+    public HookAction getAction() {
+        return action;
+    }
+
+    /**
+     * @return false if task got cancelled, true otherwise
+     */
+    public boolean performStartup() {
+        if (meetsConditions()) {
+            return doActionOnTask();
+        }
+        return true;
+    }
+
+    protected boolean meetsConditions() {
+        return false;
+    }
+
+    private boolean doActionOnTask() {
+        switch(action) {
+            case START:
+                Main.getInstance().getTaskManager().resumeTask(taskId.toString());
+                return true;
+            case PAUSE:
+                Main.getInstance().getTaskManager().pauseTask(taskId.toString());
+                return true;
+            case CANCEL:
+                Main.getInstance().getTaskManager().cancelTask(taskId.toString());
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    public boolean equals(Object o) {
+        // true if refers to this object
+        if (this == o) {
+            return true;
+        }
+        // false is object is null or not of same class
+        if (o == null || getClass() != o.getClass())
+            return false;
+        PlantHook fromO = (PlantHook)o;
+        // true if hookId and taskId match
+        return hookId == fromO.hookId && taskId == fromO.taskId;
+    }
+
+    public int hashCode() {
+        return Objects.hash(hookId, taskId);
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.hooks;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.tasks.PlantTask;
 
 import java.util.Objects;
@@ -66,13 +66,13 @@ public abstract class PlantHook {
     private boolean doActionOnTask() {
         switch(action) {
             case START:
-                Main.getInstance().getTaskManager().resumeTask(taskId.toString(), this);
+                PerformantPlants.getInstance().getTaskManager().resumeTask(taskId.toString(), this);
                 return true;
             case PAUSE:
-                Main.getInstance().getTaskManager().pauseTask(taskId.toString(), this);
+                PerformantPlants.getInstance().getTaskManager().pauseTask(taskId.toString(), this);
                 return true;
             case CANCEL:
-                Main.getInstance().getTaskManager().cancelTask(taskId.toString(), this);
+                PerformantPlants.getInstance().getTaskManager().cancelTask(taskId.toString(), this);
                 return false;
             default:
                 return false;

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHook.java
@@ -1,6 +1,7 @@
 package me.kosinkadink.performantplants.hooks;
 
 import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.tasks.PlantTask;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -11,16 +12,20 @@ public abstract class PlantHook {
     protected final UUID taskId;
     protected final HookAction action;
 
-    public PlantHook(UUID hookId, UUID taskId, HookAction action) {
+    protected String hookConfigId = "";
+
+    public PlantHook(UUID hookId, UUID taskId, HookAction action, String hookConfigId) {
         this.hookId = hookId;
         this.taskId = taskId;
         this.action = action;
+        this.hookConfigId = hookConfigId;
     }
 
-    public PlantHook(UUID taskId, HookAction action) {
+    public PlantHook(UUID taskId, HookAction action, String hookConfigId) {
         hookId = UUID.randomUUID();
         this.taskId = taskId;
         this.action = action;
+        this.hookConfigId = hookConfigId;
     }
 
     public UUID getTaskId() {
@@ -30,6 +35,19 @@ public abstract class PlantHook {
     public HookAction getAction() {
         return action;
     }
+
+    public String getHookConfigId() {
+        return hookConfigId;
+    }
+
+    public void setHookConfigId(String hookConfigId) {
+        if (hookConfigId == null) {
+            hookConfigId = "";
+        }
+        this.hookConfigId = hookConfigId;
+    }
+
+    public abstract boolean performScriptBlock(PlantTask task);
 
     /**
      * @return false if task got cancelled, true otherwise
@@ -48,13 +66,13 @@ public abstract class PlantHook {
     private boolean doActionOnTask() {
         switch(action) {
             case START:
-                Main.getInstance().getTaskManager().resumeTask(taskId.toString());
+                Main.getInstance().getTaskManager().resumeTask(taskId.toString(), this);
                 return true;
             case PAUSE:
-                Main.getInstance().getTaskManager().pauseTask(taskId.toString());
+                Main.getInstance().getTaskManager().pauseTask(taskId.toString(), this);
                 return true;
             case CANCEL:
-                Main.getInstance().getTaskManager().cancelTask(taskId.toString());
+                Main.getInstance().getTaskManager().cancelTask(taskId.toString(), this);
                 return false;
             default:
                 return false;

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlantBlock.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlantBlock.java
@@ -3,7 +3,7 @@ package me.kosinkadink.performantplants.hooks;
 import java.util.UUID;
 
 public abstract class PlantHookPlantBlock extends PlantHook {
-    public PlantHookPlantBlock(UUID taskId, HookAction action) {
-        super(taskId, action);
+    public PlantHookPlantBlock(UUID taskId, HookAction action, String hookConfigId) {
+        super(taskId, action, hookConfigId);
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlantBlock.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlantBlock.java
@@ -1,0 +1,9 @@
+package me.kosinkadink.performantplants.hooks;
+
+import java.util.UUID;
+
+public abstract class PlantHookPlantBlock extends PlantHook {
+    public PlantHookPlantBlock(UUID taskId, HookAction action) {
+        super(taskId, action);
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
@@ -1,14 +1,20 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import me.kosinkadink.performantplants.scripting.ScriptBlock;
 import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
 import me.kosinkadink.performantplants.tasks.PlantTask;
 import me.kosinkadink.performantplants.util.PlayerHelper;
 import org.bukkit.OfflinePlayer;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 
 import java.util.UUID;
 
 public abstract class PlantHookPlayer extends PlantHook {
+
+    protected static final String JSON_PLAYER_UUID = "playerUUID";
 
     protected OfflinePlayer offlinePlayer;
 
@@ -17,8 +23,42 @@ public abstract class PlantHookPlayer extends PlantHook {
         this.offlinePlayer = offlinePlayer;
     }
 
+    public PlantHookPlayer(UUID taskId, HookAction action, String hookConfigId, String jsonString) throws PlantHookJsonParseException {
+        super(taskId, action, hookConfigId);
+        loadValuesFromJsonString(jsonString);
+    }
+
     public OfflinePlayer getOfflinePlayer() {
         return offlinePlayer;
+    }
+
+    @Override
+    public String createJsonString() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(JSON_PLAYER_UUID, offlinePlayer.getUniqueId().toString());
+        return jsonObject.toJSONString();
+    }
+
+    @Override
+    public void loadValuesFromJsonString(String jsonString) throws PlantHookJsonParseException {
+        JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonString);
+        if (jsonObject == null) {
+            PerformantPlants.getInstance().getLogger().warning(String.format("Json String could not be converted to " +
+                    "JSONObject for PlantHookPlayer: %s,%s with String: %s", taskId, hookConfigId, jsonString));
+            throw new PlantHookJsonParseException(String.format("Json String could not be converted to JSONObject: %s", jsonString));
+        }
+        Object playerUUIDObject = jsonObject.getOrDefault(JSON_PLAYER_UUID, null);
+        if (playerUUIDObject == null) {
+            throw new PlantHookJsonParseException(String.format("%s String not found in JSONObject from String: %s", JSON_PLAYER_UUID, jsonString));
+        }
+        String playerUUIDString = (String) playerUUIDObject;
+        UUID playerUUID;
+        try {
+            playerUUID = UUID.fromString(playerUUIDString);
+        } catch (IllegalArgumentException e) {
+            throw new PlantHookJsonParseException(String.format("PlayerUUID was not a valid UUID: %s", playerUUIDString));
+        }
+        offlinePlayer = PerformantPlants.getInstance().getServer().getOfflinePlayer(playerUUID);
     }
 
     @Override
@@ -27,7 +67,7 @@ public abstract class PlantHookPlayer extends PlantHook {
             ScriptTask scriptTask = task.getScriptTask();
             if (scriptTask != null) {
                 ScriptBlock scriptBlock = scriptTask.getHookScriptBlock(hookConfigId);
-                if (hookConfigId != null) {
+                if (scriptBlock != null) {
                     // perform script block
                     scriptBlock.loadValue(task.getPlantBlock(), PlayerHelper.getFreshPlayer(getOfflinePlayer()));
                 }

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
@@ -1,0 +1,19 @@
+package me.kosinkadink.performantplants.hooks;
+
+import org.bukkit.OfflinePlayer;
+
+import java.util.UUID;
+
+public abstract class PlantHookPlayer extends PlantHook {
+
+    protected OfflinePlayer offlinePlayer;
+
+    public PlantHookPlayer(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
+        super(taskId, action);
+        this.offlinePlayer = offlinePlayer;
+    }
+
+    public OfflinePlayer getOfflinePlayer() {
+        return offlinePlayer;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayer.java
@@ -1,5 +1,9 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
+import me.kosinkadink.performantplants.tasks.PlantTask;
+import me.kosinkadink.performantplants.util.PlayerHelper;
 import org.bukkit.OfflinePlayer;
 
 import java.util.UUID;
@@ -8,12 +12,27 @@ public abstract class PlantHookPlayer extends PlantHook {
 
     protected OfflinePlayer offlinePlayer;
 
-    public PlantHookPlayer(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
-        super(taskId, action);
+    public PlantHookPlayer(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
+        super(taskId, action, hookConfigId);
         this.offlinePlayer = offlinePlayer;
     }
 
     public OfflinePlayer getOfflinePlayer() {
         return offlinePlayer;
+    }
+
+    @Override
+    public boolean performScriptBlock(PlantTask task) {
+        if (!hookConfigId.isEmpty()) {
+            ScriptTask scriptTask = task.getScriptTask();
+            if (scriptTask != null) {
+                ScriptBlock scriptBlock = scriptTask.getHookScriptBlock(hookConfigId);
+                if (hookConfigId != null) {
+                    // perform script block
+                    scriptBlock.loadValue(task.getPlantBlock(), PlayerHelper.getFreshPlayer(getOfflinePlayer()));
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
@@ -7,8 +7,8 @@ import org.bukkit.entity.Player;
 import java.util.UUID;
 
 public class PlantHookPlayerAlive extends PlantHookPlayer {
-    public PlantHookPlayerAlive(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
-        super(taskId, action, offlinePlayer);
+    public PlantHookPlayerAlive(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
+        super(taskId, action, hookConfigId, offlinePlayer);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
@@ -1,0 +1,23 @@
+package me.kosinkadink.performantplants.hooks;
+
+import me.kosinkadink.performantplants.util.PlayerHelper;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class PlantHookPlayerAlive extends PlantHookPlayer {
+    public PlantHookPlayerAlive(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
+        super(taskId, action, offlinePlayer);
+    }
+
+    @Override
+    protected boolean meetsConditions() {
+        if (offlinePlayer.isOnline()) {
+            Player player = (Player)offlinePlayer;
+            return PlayerHelper.isAlive(player);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerAlive.java
@@ -1,5 +1,6 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import me.kosinkadink.performantplants.util.PlayerHelper;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -7,8 +8,13 @@ import org.bukkit.entity.Player;
 import java.util.UUID;
 
 public class PlantHookPlayerAlive extends PlantHookPlayer {
+
     public PlantHookPlayerAlive(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
         super(taskId, action, hookConfigId, offlinePlayer);
+    }
+
+    public PlantHookPlayerAlive(UUID taskId, HookAction action, String hookConfigId, String jsonString) throws PlantHookJsonParseException {
+        super(taskId, action, hookConfigId, jsonString);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
@@ -1,0 +1,24 @@
+package me.kosinkadink.performantplants.hooks;
+
+import me.kosinkadink.performantplants.util.PlayerHelper;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class PlantHookPlayerDead extends PlantHookPlayer {
+
+    public PlantHookPlayerDead(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
+        super(taskId, action, offlinePlayer);
+    }
+
+    @Override
+    protected boolean meetsConditions() {
+        if (offlinePlayer.isOnline()) {
+            Player player = (Player)offlinePlayer;
+            return !PlayerHelper.isAlive(player);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
@@ -1,5 +1,6 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import me.kosinkadink.performantplants.util.PlayerHelper;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -10,6 +11,10 @@ public class PlantHookPlayerDead extends PlantHookPlayer {
 
     public PlantHookPlayerDead(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
         super(taskId, action, hookConfigId, offlinePlayer);
+    }
+
+    public PlantHookPlayerDead(UUID taskId, HookAction action, String hookConfigId, String jsonString) throws PlantHookJsonParseException {
+        super(taskId, action, hookConfigId, jsonString);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerDead.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 
 public class PlantHookPlayerDead extends PlantHookPlayer {
 
-    public PlantHookPlayerDead(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
-        super(taskId, action, offlinePlayer);
+    public PlantHookPlayerDead(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
+        super(taskId, action, hookConfigId, offlinePlayer);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
@@ -1,5 +1,6 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import org.bukkit.OfflinePlayer;
 
 import java.util.UUID;
@@ -8,6 +9,10 @@ public class PlantHookPlayerOffline extends PlantHookPlayer {
 
     public PlantHookPlayerOffline(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
         super(taskId, action, hookConfigId, offlinePlayer);
+    }
+
+    public PlantHookPlayerOffline(UUID taskId, HookAction action, String hookConfigId, String jsonString) throws PlantHookJsonParseException {
+        super(taskId, action, hookConfigId, jsonString);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 
 public class PlantHookPlayerOffline extends PlantHookPlayer {
 
-    public PlantHookPlayerOffline(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
-        super(taskId, action, offlinePlayer);
+    public PlantHookPlayerOffline(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
+        super(taskId, action, hookConfigId, offlinePlayer);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOffline.java
@@ -1,0 +1,18 @@
+package me.kosinkadink.performantplants.hooks;
+
+import org.bukkit.OfflinePlayer;
+
+import java.util.UUID;
+
+public class PlantHookPlayerOffline extends PlantHookPlayer {
+
+    public PlantHookPlayerOffline(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
+        super(taskId, action, offlinePlayer);
+    }
+
+    @Override
+    protected boolean meetsConditions() {
+        return !offlinePlayer.isOnline();
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
@@ -1,5 +1,6 @@
 package me.kosinkadink.performantplants.hooks;
 
+import me.kosinkadink.performantplants.exceptions.PlantHookJsonParseException;
 import org.bukkit.OfflinePlayer;
 
 import java.util.UUID;
@@ -8,6 +9,10 @@ public class PlantHookPlayerOnline extends PlantHookPlayer {
 
     public PlantHookPlayerOnline(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
         super(taskId, action, hookConfigId, offlinePlayer);
+    }
+
+    public PlantHookPlayerOnline(UUID taskId, HookAction action, String hookConfigId, String jsonString) throws PlantHookJsonParseException {
+        super(taskId, action, hookConfigId, jsonString);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
@@ -1,0 +1,18 @@
+package me.kosinkadink.performantplants.hooks;
+
+import org.bukkit.OfflinePlayer;
+
+import java.util.UUID;
+
+public class PlantHookPlayerOnline extends PlantHookPlayer {
+
+    public PlantHookPlayerOnline(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
+        super(taskId, action, offlinePlayer);
+    }
+
+    @Override
+    protected boolean meetsConditions() {
+        return offlinePlayer.isOnline();
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
+++ b/src/main/java/me/kosinkadink/performantplants/hooks/PlantHookPlayerOnline.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 
 public class PlantHookPlayerOnline extends PlantHookPlayer {
 
-    public PlantHookPlayerOnline(UUID taskId, HookAction action, OfflinePlayer offlinePlayer) {
-        super(taskId, action, offlinePlayer);
+    public PlantHookPlayerOnline(UUID taskId, HookAction action, String hookConfigId, OfflinePlayer offlinePlayer) {
+        super(taskId, action, hookConfigId, offlinePlayer);
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/listeners/BlockBreakListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/BlockBreakListener.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.events.PlantBreakEvent;
 import me.kosinkadink.performantplants.util.MetadataHelper;
@@ -10,10 +10,10 @@ import org.bukkit.event.block.BlockBreakEvent;
 
 public class BlockBreakListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public BlockBreakListener(Main mainClass) {
-        main = mainClass;
+    public BlockBreakListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
@@ -22,16 +22,16 @@ public class BlockBreakListener implements Listener {
         if (!event.isCancelled() &&
                 MetadataHelper.hasPlantBlockMetadata(event.getBlock())) {
             event.setCancelled(true);
-            PlantBlock plantBlock = main.getPlantManager().getPlantBlock(event.getBlock());
+            PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(event.getBlock());
             // if plant block is registered, call plant break event
             if (plantBlock != null) {
-                main.getServer().getPluginManager().callEvent(
+                performantPlants.getServer().getPluginManager().callEvent(
                         new PlantBreakEvent(event.getPlayer(), plantBlock, event.getBlock())
                 );
             }
             // otherwise, remove faulty metadata
             else {
-                MetadataHelper.removePlantBlockMetadata(main, event.getBlock());
+                MetadataHelper.removePlantBlockMetadata(performantPlants, event.getBlock());
             }
         }
     }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/ChunkEventListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/ChunkEventListener.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.chunks.PlantChunk;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,20 +10,20 @@ import org.bukkit.event.world.ChunkUnloadEvent;
 
 public class ChunkEventListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public ChunkEventListener(Main mainClass) {
-        main = mainClass;
+    public ChunkEventListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         // check if player logged in at plant chunk
-        main.getServer().getScheduler().runTaskLaterAsynchronously(main, () -> {
-            PlantChunk plantChunk = main.getPlantManager().getPlantChunk(event.getPlayer().getLocation().getChunk());
+        performantPlants.getServer().getScheduler().runTaskLaterAsynchronously(performantPlants, () -> {
+            PlantChunk plantChunk = performantPlants.getPlantManager().getPlantChunk(event.getPlayer().getLocation().getChunk());
             if (plantChunk != null) {
                 // load plantChunk
-                plantChunk.load(main);
+                plantChunk.load(performantPlants);
             }
         }, 5);
     }
@@ -32,12 +32,12 @@ public class ChunkEventListener implements Listener {
     public void onChunkLoad(ChunkLoadEvent event) {
         // check if not new chunk
         if (!event.isNewChunk()) {
-            main.getServer().getScheduler().runTaskAsynchronously(main, () -> {
+            performantPlants.getServer().getScheduler().runTaskAsynchronously(performantPlants, () -> {
                 // check if plant chunk
-                PlantChunk plantChunk = main.getPlantManager().getPlantChunk(event.getChunk());
+                PlantChunk plantChunk = performantPlants.getPlantManager().getPlantChunk(event.getChunk());
                 if (plantChunk != null) {
                     // load plantChunk
-                    plantChunk.load(main);
+                    plantChunk.load(performantPlants);
                 }
             });
         }
@@ -45,12 +45,12 @@ public class ChunkEventListener implements Listener {
 
     @EventHandler
     public void onChunkUnload(ChunkUnloadEvent event) {
-        main.getServer().getScheduler().runTaskAsynchronously(main, () -> {
+        performantPlants.getServer().getScheduler().runTaskAsynchronously(performantPlants, () -> {
             // get plantChunk
-            PlantChunk plantChunk = main.getPlantManager().getPlantChunk(event.getChunk());
+            PlantChunk plantChunk = performantPlants.getPlantManager().getPlantChunk(event.getChunk());
             if (plantChunk != null) {
                 // unload plantChunk
-                plantChunk.unload(main);
+                plantChunk.unload(performantPlants);
             }
         });
     }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/HookListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/HookListener.java
@@ -1,0 +1,43 @@
+package me.kosinkadink.performantplants.listeners;
+
+import me.kosinkadink.performantplants.Main;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+public class HookListener implements Listener {
+
+    private final Main main;
+
+    public HookListener(Main main) {
+        this.main = main;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        // check if player has a registered hook
+        main.getTaskManager().triggerPlayerOnlineHooks(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        // check if player has a registered hook
+        main.getTaskManager().triggerPlayerAliveHooks(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        // check if player has a registered hook
+        main.getTaskManager().triggerPlayerOfflineHooks(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        // check if player has a registered hook
+        main.getTaskManager().triggerPlayerDeadHooks(event.getEntity());
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/listeners/HookListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/HookListener.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -10,34 +10,34 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 
 public class HookListener implements Listener {
 
-    private final Main main;
+    private final PerformantPlants performantPlants;
 
-    public HookListener(Main main) {
-        this.main = main;
+    public HookListener(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         // check if player has a registered hook
-        main.getTaskManager().triggerPlayerOnlineHooks(event.getPlayer());
+        performantPlants.getTaskManager().triggerPlayerOnlineHooks(event.getPlayer());
     }
 
     @EventHandler
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         // check if player has a registered hook
-        main.getTaskManager().triggerPlayerAliveHooks(event.getPlayer());
+        performantPlants.getTaskManager().triggerPlayerAliveHooks(event.getPlayer());
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         // check if player has a registered hook
-        main.getTaskManager().triggerPlayerOfflineHooks(event.getPlayer());
+        performantPlants.getTaskManager().triggerPlayerOfflineHooks(event.getPlayer());
     }
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         // check if player has a registered hook
-        main.getTaskManager().triggerPlayerDeadHooks(event.getEntity());
+        performantPlants.getTaskManager().triggerPlayerDeadHooks(event.getEntity());
     }
 
 }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/PlantBlockEventListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/PlantBlockEventListener.java
@@ -106,7 +106,7 @@ public class PlantBlockEventListener implements Listener {
                 boolean onlyEffectsOnDo = plantInteract.isOnlyEffectsOnDo(event.getPlayer(), event.getPlantBlock());
                 boolean onlyConsumableEffectsOnDo = plantInteract.isOnlyConsumableEffectsOnDo(event.getPlayer(), event.getPlantBlock());
                 // see if drops should occur
-                giveBlockDrops = plantInteract.isGiveBlockDrops(event.getPlayer(), event.getPlantBlock());
+                giveBlockDrops = plantInteract.isGiveBlockDropsNull() || plantInteract.isGiveBlockDrops(event.getPlayer(), event.getPlantBlock());
                 // determine if block should be broken
                 if (!onlyBreakOnDo || shouldDo) {
                     if (!plantInteract.isBreakBlockNull() && !plantInteract.isBreakBlock(event.getPlayer(), event.getPlantBlock())) {

--- a/src/main/java/me/kosinkadink/performantplants/listeners/PlantBlockEventListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/PlantBlockEventListener.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.events.*;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -28,10 +28,10 @@ import java.util.List;
 
 public class PlantBlockEventListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlantBlockEventListener(Main mainClass) {
-        main = mainClass;
+    public PlantBlockEventListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
@@ -42,14 +42,14 @@ public class PlantBlockEventListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
-            if (main.getConfigManager().getConfigSettings().isDebug())
-                main.getLogger().info("Reviewing PlantPlaceEvent for block: " + event.getBlock().getLocation().toString());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                performantPlants.getLogger().info("Reviewing PlantPlaceEvent for block: " + event.getBlock().getLocation().toString());
             Block block = event.getBlock();
             if (block.isEmpty()) {
                 // check if empty block has plant metadata
                 if (MetadataHelper.hasPlantBlockMetadata(block)) {
                     // if so, destroy; erroneous existence and continue
-                    BlockHelper.destroyPlantBlock(main, block, false);
+                    BlockHelper.destroyPlantBlock(performantPlants, block, false);
                 }
                 // get item in appropriate hand hand
                 ItemStack itemStack;
@@ -69,14 +69,14 @@ public class PlantBlockEventListener implements Listener {
                 if (plantBlock.isGrows()) {
                     // set newly placed; will check plant requirements instead of growth requirements, if present
                     plantBlock.setNewlyPlaced(true);
-                    if (!plantBlock.checkAllRequirements(main)) {
+                    if (!plantBlock.checkAllRequirements(performantPlants)) {
                         event.setCancelled(true);
                         return;
                     }
                 }
                 // set block orientation (only used if orientable block to be placed)
                 plantBlock.setBlockYaw(event.getPlayer().getLocation().getYaw());
-                main.getPlantManager().addPlantBlock(plantBlock);
+                performantPlants.getPlantManager().addPlantBlock(plantBlock);
                 decrementItemStack(itemStack);
             }
         }
@@ -90,8 +90,8 @@ public class PlantBlockEventListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
-            if (main.getConfigManager().getConfigSettings().isDebug())
-                main.getLogger().info("Reviewing PlantBreakEvent for block: " + event.getBlock().getLocation().toString());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                performantPlants.getLogger().info("Reviewing PlantBreakEvent for block: " + event.getBlock().getLocation().toString());
             // track if block should break and if drops should occur
             boolean actuallyBreakBlock = true;
             boolean giveBlockDrops = true;
@@ -141,7 +141,7 @@ public class PlantBlockEventListener implements Listener {
                 }
             }
             if (actuallyBreakBlock) {
-                BlockHelper.destroyPlantBlock(main, event.getBlock(), event.getPlantBlock(), giveBlockDrops);
+                BlockHelper.destroyPlantBlock(performantPlants, event.getBlock(), event.getPlantBlock(), giveBlockDrops);
                 event.setBlockBroken(true);
             }
         }
@@ -155,12 +155,12 @@ public class PlantBlockEventListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
-            if (main.getConfigManager().getConfigSettings().isDebug())
-                main.getLogger().info("Reviewing PlantFarmlandTrampleEvent for block: " + event.getBlock().getLocation().toString());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                performantPlants.getLogger().info("Reviewing PlantFarmlandTrampleEvent for block: " + event.getBlock().getLocation().toString());
             // set trampled block to dirt for growth requirement check purposes
             event.getTrampledBlock().setType(Material.DIRT);
             if (!event.getPlantBlock().checkGrowthRequirements()) {
-                BlockHelper.destroyPlantBlock(main, event.getBlock(), event.getPlantBlock(), true);
+                BlockHelper.destroyPlantBlock(performantPlants, event.getBlock(), event.getPlantBlock(), true);
             }
             // set it back to farmland to avoid weird effect on player
             // actual turning into dirt should happen due to PlayerInteractEvent not being cancelled
@@ -181,8 +181,8 @@ public class PlantBlockEventListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
-            if (main.getConfigManager().getConfigSettings().isDebug())
-                main.getLogger().info("Reviewing PlantInteractEvent for block: " + event.getBlock().getLocation().toString());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                performantPlants.getLogger().info("Reviewing PlantInteractEvent for block: " + event.getBlock().getLocation().toString());
             // get item in main hand
             EquipmentSlot hand = EquipmentSlot.HAND;
             ItemStack itemStack = event.getPlayer().getInventory().getItemInMainHand();
@@ -225,7 +225,7 @@ public class PlantBlockEventListener implements Listener {
             // break block, if applicable
             if (!onlyBreakOnDo || shouldDo) {
                 if (plantInteract.isBreakBlock(event.getPlayer(), event.getPlantBlock())) {
-                    BlockHelper.destroyPlantBlock(main, event.getBlock(), event.getPlantBlock(), plantInteract.isGiveBlockDrops(event.getPlayer(), event.getPlantBlock()));
+                    BlockHelper.destroyPlantBlock(performantPlants, event.getBlock(), event.getPlantBlock(), plantInteract.isGiveBlockDrops(event.getPlayer(), event.getPlantBlock()));
                 }
             }
             // drop items, if applicable
@@ -270,10 +270,10 @@ public class PlantBlockEventListener implements Listener {
             event.setCancelled(true);
             return;
         }
-        if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Reviewing PlantConsumeEvent for item");
+        if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Reviewing PlantConsumeEvent for item");
         PlantConsumable plantConsumable = event.getConsumable();
         if (plantConsumable == null) {
-            if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Consumable not found for current inventory status");
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Consumable not found for current inventory status");
             event.setCancelled(true);
             return;
         }
@@ -419,7 +419,7 @@ public class PlantBlockEventListener implements Listener {
         if (!event.isCancelled()) {
             if (MetadataHelper.hasPlantBlockMetadata(event.getBlock())) {
                 event.setCancelled(true);
-                BlockHelper.destroyPlantBlock(main, event.getBlock(), false);
+                BlockHelper.destroyPlantBlock(performantPlants, event.getBlock(), false);
             }
         }
     }
@@ -429,7 +429,7 @@ public class PlantBlockEventListener implements Listener {
         // check if exploded blocks were Plants, and if so destroy them
         for (Block block : event.blockList()) {
             if (MetadataHelper.hasPlantBlockMetadata(block)) {
-                BlockHelper.destroyPlantBlock(main, block, false);
+                BlockHelper.destroyPlantBlock(performantPlants, block, false);
             }
         }
     }
@@ -439,7 +439,7 @@ public class PlantBlockEventListener implements Listener {
         // check if exploded blocks were Plants, and if so destroy them
         for (Block block : event.blockList()) {
             if (MetadataHelper.hasPlantBlockMetadata(block)) {
-                BlockHelper.destroyPlantBlock(main, block, false);
+                BlockHelper.destroyPlantBlock(performantPlants, block, false);
             }
         }
     }
@@ -449,7 +449,7 @@ public class PlantBlockEventListener implements Listener {
         if (MetadataHelper.hasPlantBlockMetadata(event.getToBlock()) &&
                 !event.getToBlock().getType().isSolid()) {
             Block block = event.getToBlock();
-            BlockHelper.destroyPlantBlock(main, block, true);
+            BlockHelper.destroyPlantBlock(performantPlants, block, true);
             event.setCancelled(true);
         }
     }
@@ -463,10 +463,10 @@ public class PlantBlockEventListener implements Listener {
             if (source.getType().isAir() &&
                     !block.getType().isSolid() &&
                     block.getLocation().getBlockY()-source.getLocation().getBlockY() > 0) {
-                BlockHelper.destroyPlantBlock(main, block, true);
+                BlockHelper.destroyPlantBlock(performantPlants, block, true);
                 // only destroy source block if it is a plant block
                 if (MetadataHelper.hasPlantBlockMetadata(source)) {
-                    BlockHelper.destroyPlantBlock(main, source, true);
+                    BlockHelper.destroyPlantBlock(performantPlants, source, true);
                 }
             }
             event.setCancelled(true);
@@ -502,7 +502,7 @@ public class PlantBlockEventListener implements Listener {
             if (anyPlantBlocks) {
                 // destroy any plant blocks immediately being moved by piston
                 if (MetadataHelper.hasPlantBlockMetadata(eventBlocks.get(0))) {
-                    BlockHelper.destroyPlantBlock(main, eventBlocks.get(0), true);
+                    BlockHelper.destroyPlantBlock(performantPlants, eventBlocks.get(0), true);
                     if (eventBlocks.get(0).getType().isSolid()) {
                         event.setCancelled(true);
                     }
@@ -552,7 +552,7 @@ public class PlantBlockEventListener implements Listener {
                     }
                     // destroy any plant blocks marked for destruction
                     for (Block plantBlock : plantBlocksToDestroy) {
-                        BlockHelper.destroyPlantBlock(main, plantBlock, true);
+                        BlockHelper.destroyPlantBlock(performantPlants, plantBlock, true);
                     }
                 }
             }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/PlayerInteractListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/PlayerInteractListener.java
@@ -28,7 +28,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class PlayerInteractListener implements Listener {
 
-    private PerformantPlants performantPlants;
+    private final PerformantPlants performantPlants;
 
     public PlayerInteractListener(PerformantPlants performantPlantsClass) {
         performantPlants = performantPlantsClass;

--- a/src/main/java/me/kosinkadink/performantplants/listeners/PlayerInteractListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/PlayerInteractListener.java
@@ -1,8 +1,7 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
-import me.kosinkadink.performantplants.builders.PlantItemBuilder;
 import me.kosinkadink.performantplants.events.PlantConsumeEvent;
 import me.kosinkadink.performantplants.events.PlantFarmlandTrampleEvent;
 import me.kosinkadink.performantplants.events.PlantInteractEvent;
@@ -10,9 +9,7 @@ import me.kosinkadink.performantplants.events.PlantPlaceEvent;
 import me.kosinkadink.performantplants.plants.Plant;
 import me.kosinkadink.performantplants.plants.PlantConsumable;
 import me.kosinkadink.performantplants.plants.PlantItem;
-import me.kosinkadink.performantplants.plants.RequiredItem;
 import me.kosinkadink.performantplants.util.BlockHelper;
-import me.kosinkadink.performantplants.util.ItemHelper;
 import me.kosinkadink.performantplants.util.MetadataHelper;
 import me.kosinkadink.performantplants.util.PlayerHelper;
 import org.bukkit.Material;
@@ -22,6 +19,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -30,16 +28,16 @@ import org.bukkit.inventory.ItemStack;
 
 public class PlayerInteractListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public PlayerInteractListener(Main mainClass) {
-        main = mainClass;
+    public PlayerInteractListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
         if (event.getBlockAgainst().getType() == Material.CAMPFIRE) {
-            if (main.getPlantTypeManager().isPlantItemStack(event.getItemInHand())) {
+            if (performantPlants.getPlantTypeManager().isPlantItemStack(event.getItemInHand())) {
                 event.setCancelled(true);
             }
         }
@@ -47,10 +45,10 @@ public class PlayerInteractListener implements Listener {
 
     @EventHandler
     public void onPlayerItemConsume(PlayerItemConsumeEvent event) {
-        PlantItem plantItem = main.getPlantTypeManager().getPlantItemByItemStack(event.getItem());
+        PlantItem plantItem = performantPlants.getPlantTypeManager().getPlantItemByItemStack(event.getItem());
         if (plantItem != null) {
-            // create PlantConsumeEvent if is consumable by default consume
             event.setCancelled(true);
+            // create PlantConsumeEvent if is consumable by default consume
             if (plantItem.getConsumableStorage() != null) {
                 EquipmentSlot hand;
                 if (event.getItem().isSimilar(event.getPlayer().getInventory().getItemInOffHand())) {
@@ -60,7 +58,7 @@ public class PlayerInteractListener implements Listener {
                 }
                 PlantConsumable consumable = plantItem.getConsumableStorage().getConsumable(event.getPlayer(), hand);
                 if (consumable != null && consumable.isNormalEat()) {
-                    main.getServer().getPluginManager().callEvent(
+                    performantPlants.getServer().getPluginManager().callEvent(
                             new PlantConsumeEvent(event.getPlayer(), consumable, hand)
                     );
                 }
@@ -76,7 +74,7 @@ public class PlayerInteractListener implements Listener {
         } else {
             itemStack = event.getPlayer().getInventory().getItemInMainHand();
         }
-        PlantItem plantItem = main.getPlantTypeManager().getPlantItemByItemStack(itemStack);
+        PlantItem plantItem = performantPlants.getPlantTypeManager().getPlantItemByItemStack(itemStack);
         // don't let plant items be used to feed animals/be interacted with entities
         if (plantItem != null) {
             event.setCancelled(true);
@@ -96,13 +94,13 @@ public class PlayerInteractListener implements Listener {
                 return;
             }
             otherStack = player.getInventory().getItemInMainHand();
-            if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Reviewing PlayerInteractEvent for Off Hand");
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Reviewing PlayerInteractEvent for Off Hand");
         }
         else {
             // interacting with main hand
             itemStack = player.getInventory().getItemInMainHand();
             otherStack = player.getInventory().getItemInOffHand();
-            if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Reviewing PlayerInteractEvent for Main Hand");
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Reviewing PlayerInteractEvent for Main Hand");
         }
         Block block = event.getClickedBlock();
         // check if block is farmland; if so, got trampled
@@ -116,10 +114,10 @@ public class PlayerInteractListener implements Listener {
                         );
                         if (MetadataHelper.hasPlantBlockMetadata(blockAbove)) {
                             // create PlantFarmlandTrampleEvent
-                            PlantBlock plantBlock = main.getPlantManager().getPlantBlock(blockAbove);
+                            PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(blockAbove);
                             // don't cancel event so the farmland will end up turning into dirt
                             if (plantBlock != null) {
-                                main.getServer().getPluginManager().callEvent(
+                                performantPlants.getServer().getPluginManager().callEvent(
                                         new PlantFarmlandTrampleEvent(event.getPlayer(), plantBlock, blockAbove, block)
                                 );
                                 return;
@@ -139,11 +137,11 @@ public class PlayerInteractListener implements Listener {
                     block != null &&
                     MetadataHelper.hasPlantBlockMetadata(block)) {
                 // get plant block interacted with
-                PlantBlock plantBlock = main.getPlantManager().getPlantBlock(block);
+                PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(block);
                 if (plantBlock != null && !player.isSneaking()) {
                     // cancel event and send out PlantInteractEvent ONLY IF main hand to avoid double interaction
                     event.setCancelled(true);
-                    main.getServer().getPluginManager().callEvent(
+                    performantPlants.getServer().getPluginManager().callEvent(
                             new PlantInteractEvent(player, plantBlock, block, event.getBlockFace(), event.getHand())
                     );
                     return;
@@ -151,20 +149,20 @@ public class PlayerInteractListener implements Listener {
             }
             // check if trying to place down plant or consume plant item
             if (itemStack.getType() != Material.AIR) {
-                Plant plant = main.getPlantTypeManager().getPlantByItemStack(itemStack);
+                Plant plant = performantPlants.getPlantTypeManager().getPlantByItemStack(itemStack);
                 if (plant != null) {
                     PlantItem plantItem;
                     if (event.getAction() == Action.RIGHT_CLICK_BLOCK &&
                             block != null) {
                         // if block is inventory holder and player is sneaking, open block's inventory
                         if (block.getType() == Material.CAMPFIRE) {
-                            if (main.getConfigManager().getConfigSettings().isDebug())
-                                main.getLogger().info("Right clicked on campfire holding a plant item");
+                            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                                performantPlants.getLogger().info("Right clicked on campfire holding a plant item");
                             return;
                         }
                         if (BlockHelper.isInteractable(block) && !player.isSneaking()) {
-                            if (main.getConfigManager().getConfigSettings().isDebug())
-                                main.getLogger().info("Prevented block from being placed on interactable block");
+                            if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                                performantPlants.getLogger().info("Prevented block from being placed on interactable block");
                             return;
                         }
                         // check if item is consumable or player is sneaking
@@ -174,7 +172,7 @@ public class PlayerInteractListener implements Listener {
                             event.setCancelled(true);
                             if (plant.hasSeed() && plant.getSeedItemStack().isSimilar(itemStack)) {
                                 // cancel event and send out PlantBlockEvent
-                                main.getServer().getPluginManager().callEvent(
+                                performantPlants.getServer().getPluginManager().callEvent(
                                         new PlantPlaceEvent(player, plant, block.getRelative(event.getBlockFace()), event.getHand(), true)
                                 );
                                 return;
@@ -187,7 +185,7 @@ public class PlayerInteractListener implements Listener {
                         // if in offhand and main hand is consumable, don't do anything
                         boolean performConsumeForThisHand = true;
                         if (event.getHand() == EquipmentSlot.OFF_HAND) {
-                            PlantItem otherItem = main.getPlantTypeManager().getPlantItemByItemStack(otherStack);
+                            PlantItem otherItem = performantPlants.getPlantTypeManager().getPlantItemByItemStack(otherStack);
                             if (otherItem != null && otherItem.isConsumable()) {
                                 performConsumeForThisHand = false;
                             }
@@ -196,27 +194,27 @@ public class PlayerInteractListener implements Listener {
                             PlantConsumable consumable = plantItem.getConsumableStorage().getConsumable(player, event.getHand());
                             if (!plantItem.getItemStack().getType().isEdible() || (consumable != null && !consumable.isNormalEat())) {
                                 event.setCancelled(true);
-                                main.getServer().getPluginManager().callEvent(
+                                performantPlants.getServer().getPluginManager().callEvent(
                                         new PlantConsumeEvent(player, consumable, event.getHand())
                                 );
                             }
                         }
                     }
-                    if (main.getConfigManager().getConfigSettings().isDebug())
-                        main.getLogger().info("Block was NULL");
+                    if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                        performantPlants.getLogger().info("Block was NULL");
                 } else {
                     // check if item in other hand is consumable
-                    if (!otherStack.getType().isAir() && !itemStack.getType().isEdible() && !main.getPlantTypeManager().isPlantItemStack(itemStack)) {
-                        PlantItem otherItem = main.getPlantTypeManager().getPlantItemByItemStack(otherStack);
+                    if (!otherStack.getType().isAir() && !itemStack.getType().isEdible() && !performantPlants.getPlantTypeManager().isPlantItemStack(itemStack)) {
+                        PlantItem otherItem = performantPlants.getPlantTypeManager().getPlantItemByItemStack(otherStack);
                         if (otherItem != null && otherItem.isConsumable()) {
                             PlantConsumable otherConsumable = otherItem.getConsumableStorage().getConsumable(player,
                                     PlayerHelper.oppositeHand(event.getHand()));
                             if (otherConsumable != null) {
                                 event.setCancelled(true);
-                                if (main.getConfigManager().getConfigSettings().isDebug())
-                                    main.getLogger().info("Prevented required block for consumable to perform its own action");
+                                if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                                    performantPlants.getLogger().info("Prevented required block for consumable to perform its own action");
                                 if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.getHand() == EquipmentSlot.HAND) {
-                                    main.getServer().getPluginManager().callEvent(
+                                    performantPlants.getServer().getPluginManager().callEvent(
                                             new PlantConsumeEvent(player, otherConsumable, EquipmentSlot.OFF_HAND)
                                     );
                                 }
@@ -224,8 +222,8 @@ public class PlayerInteractListener implements Listener {
                             }
                         }
                     }
-                    if (main.getConfigManager().getConfigSettings().isDebug())
-                        main.getLogger().info("Plant was NULL, doing nothing");
+                    if (performantPlants.getConfigManager().getConfigSettings().isDebug())
+                        performantPlants.getLogger().info("Plant was NULL, doing nothing");
                 }
             }
         }
@@ -237,10 +235,10 @@ public class PlayerInteractListener implements Listener {
                     block != null &&
                     MetadataHelper.hasPlantBlockMetadata(block)) {
                 // get plant block interacted with
-                PlantBlock plantBlock = main.getPlantManager().getPlantBlock(block);
+                PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(block);
                 if (plantBlock != null) {
                     PlantInteractEvent plantInteractEvent = new PlantInteractEvent(player, plantBlock, block, event.getBlockFace(), event.getHand(), true);
-                    main.getServer().getPluginManager().callEvent(
+                    performantPlants.getServer().getPluginManager().callEvent(
                             plantInteractEvent
                     );
                     return;
@@ -248,14 +246,14 @@ public class PlayerInteractListener implements Listener {
             }
             // check if there is any general or vanilla click behavior
             if (itemStack.getType() != Material.AIR) {
-                Plant plant = main.getPlantTypeManager().getPlantByItemStack(itemStack);
+                Plant plant = performantPlants.getPlantTypeManager().getPlantByItemStack(itemStack);
                 if (plant != null) {
                     PlantItem plantItem;
                     plantItem = plant.getItemByItemStack(itemStack);
                     if (plantItem.isClickable()) {
                         PlantConsumable consumable = plantItem.getClickableStorage().getConsumable(player, event.getHand());
                         if (consumable != null) {
-                            main.getServer().getPluginManager().callEvent(
+                            performantPlants.getServer().getPluginManager().callEvent(
                                     new PlantConsumeEvent(player, consumable, event.getHand())
                             );
                         }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/RecipeEventListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/RecipeEventListener.java
@@ -1,9 +1,8 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.builders.ItemBuilder;
-import me.kosinkadink.performantplants.builders.PlantItemBuilder;
 import me.kosinkadink.performantplants.plants.PlantConsumable;
 import me.kosinkadink.performantplants.plants.PlantInteract;
 import me.kosinkadink.performantplants.plants.PlantRecipe;
@@ -22,19 +21,19 @@ import org.bukkit.inventory.*;
 
 public class RecipeEventListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public RecipeEventListener(Main mainClass) {
-        main = mainClass;
+    public RecipeEventListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
     public void onPrepareItemCraft(PrepareItemCraftEvent event) {
         // check if a vanilla recipe is trying to use a plant item
-        if (!main.getRecipeManager().isRecipe(event.getRecipe())) {
+        if (!performantPlants.getRecipeManager().isRecipe(event.getRecipe())) {
             for (ItemStack ingredient : event.getInventory().getMatrix()) {
                 // if plant item is used, set result to air
-                if (main.getPlantTypeManager().isPlantItemStack(ingredient)) {
+                if (performantPlants.getPlantTypeManager().isPlantItemStack(ingredient)) {
                     event.getInventory().setResult(new ItemStack(Material.AIR));
                     return;
                 }
@@ -45,7 +44,7 @@ public class RecipeEventListener implements Listener {
     @EventHandler
     public void onCraftItem(CraftItemEvent event) {
         if (!event.isCancelled()) {
-            PlantRecipe plantRecipe = main.getRecipeManager().getRecipe(event.getRecipe());
+            PlantRecipe plantRecipe = performantPlants.getRecipeManager().getRecipe(event.getRecipe());
             if (plantRecipe == null) {
                 return;
             }
@@ -88,25 +87,25 @@ public class RecipeEventListener implements Listener {
     @EventHandler
     public void onFurnaceSmelt(FurnaceSmeltEvent event) {
         // check if a smelting recipe was registered for item stack
-        if (main.getPlantTypeManager().isPlantItemStack(event.getSource())) {
+        if (performantPlants.getPlantTypeManager().isPlantItemStack(event.getSource())) {
             switch (event.getBlock().getType()) {
                 case FURNACE:
-                    if (!main.getRecipeManager().isInputForFurnaceRecipe(event.getSource())) {
+                    if (!performantPlants.getRecipeManager().isInputForFurnaceRecipe(event.getSource())) {
                         event.setCancelled(true);
                     }
                     break;
                 case BLAST_FURNACE:
-                    if (!main.getRecipeManager().isInputForBlastingRecipe(event.getSource())) {
+                    if (!performantPlants.getRecipeManager().isInputForBlastingRecipe(event.getSource())) {
                         event.setCancelled(true);
                     }
                     break;
                 case SMOKER:
-                    if (!main.getRecipeManager().isInputForSmokingRecipe(event.getSource())) {
+                    if (!performantPlants.getRecipeManager().isInputForSmokingRecipe(event.getSource())) {
                         event.setCancelled(true);
                     }
                     break;
                 case CAMPFIRE:
-                    if (!main.getRecipeManager().isInputForCampfireRecipe(event.getSource())) {
+                    if (!performantPlants.getRecipeManager().isInputForCampfireRecipe(event.getSource())) {
                         event.setCancelled(true);
                     }
                     break;
@@ -120,7 +119,7 @@ public class RecipeEventListener implements Listener {
     public void onFurnaceBurn(FurnaceBurnEvent event) {
         // check if a plant item is about to be used as fuel
         // cancel if plant
-        if (main.getPlantTypeManager().isPlantItemStack(event.getFuel())) {
+        if (performantPlants.getPlantTypeManager().isPlantItemStack(event.getFuel())) {
             event.setCancelled(true);
             return;
         }
@@ -128,7 +127,7 @@ public class RecipeEventListener implements Listener {
         InventoryHolder inventoryHolder = (InventoryHolder) event.getBlock().getState();
         FurnaceInventory furnaceInventory = (FurnaceInventory) inventoryHolder.getInventory();
         // check if a smelting recipe was registered for item stack
-        if (main.getPlantTypeManager().isPlantItemStack(furnaceInventory.getSmelting()) && !main.getRecipeManager().isInputForFurnaceRecipe(furnaceInventory.getSmelting())) {
+        if (performantPlants.getPlantTypeManager().isPlantItemStack(furnaceInventory.getSmelting()) && !performantPlants.getRecipeManager().isInputForFurnaceRecipe(furnaceInventory.getSmelting())) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/kosinkadink/performantplants/listeners/VanillaDropListener.java
+++ b/src/main/java/me/kosinkadink/performantplants/listeners/VanillaDropListener.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.listeners;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.builders.ItemBuilder;
 import me.kosinkadink.performantplants.plants.PlantConsumable;
@@ -21,15 +21,15 @@ import org.bukkit.inventory.ItemStack;
 
 public class VanillaDropListener implements Listener {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
-    public VanillaDropListener(Main mainClass) {
-        main = mainClass;
+    public VanillaDropListener(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     @EventHandler
     public void onEntityDeath(EntityDeathEvent event) {
-        PlantInteractStorage storage = main.getVanillaDropManager().getInteract(event.getEntityType());
+        PlantInteractStorage storage = performantPlants.getVanillaDropManager().getInteract(event.getEntityType());
         if (storage != null) {
             Player player = event.getEntity().getKiller();
             ItemStack heldItem;
@@ -67,7 +67,7 @@ public class VanillaDropListener implements Listener {
         }
         Block block = event.getBlock();
         // otherwise, check if have custom drops
-        PlantInteractStorage storage = main.getVanillaDropManager().getInteract(block);
+        PlantInteractStorage storage = performantPlants.getVanillaDropManager().getInteract(block);
         if (storage != null) {
             Player player = event.getPlayer();
             ItemStack heldItem = player.getInventory().getItemInMainHand();

--- a/src/main/java/me/kosinkadink/performantplants/managers/CommandManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/CommandManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.commands.PPCommand;
 import me.kosinkadink.performantplants.executors.PPCommandExecutor;
 
@@ -10,14 +10,14 @@ import java.util.Objects;
 
 public class CommandManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
     private PPCommandExecutor PPCommandExecutor;
     private List<PPCommand> registeredCommands = new ArrayList<>();
     private String commandRoot = "pp";
 
-    public CommandManager(Main mainClass) {
-        main = mainClass;
-        PPCommandExecutor = new PPCommandExecutor(mainClass);
+    public CommandManager(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
+        PPCommandExecutor = new PPCommandExecutor(performantPlantsClass);
     }
 
     public List<PPCommand> getRegisteredCommands() {
@@ -25,7 +25,7 @@ public class CommandManager {
     }
 
     public void registerCommand(PPCommand ppCommand) {
-        Objects.requireNonNull(main.getCommand(commandRoot)).setExecutor(PPCommandExecutor);
+        Objects.requireNonNull(performantPlants.getCommand(commandRoot)).setExecutor(PPCommandExecutor);
         registeredCommands.add(ppCommand);
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
@@ -3039,18 +3039,23 @@ public class ConfigurationManager {
         try {
             if (section == null) {
                 return null;
-            } else if (section.isBoolean(subsectionName)) {
-                return new ScriptResult(section.getBoolean(subsectionName));
-            } else if (section.isInt(subsectionName)) {
-                return new ScriptResult(section.getInt(subsectionName));
-            } else if (section.isLong(subsectionName)) {
-                return new ScriptResult(section.getLong(subsectionName));
-            } else if (section.isDouble(subsectionName)) {
-                return new ScriptResult(section.getDouble(subsectionName));
-            } else if (section.isString(subsectionName)) {
-                return new ScriptResult(section.getString(subsectionName));
+            }
+            else if (subsectionName != null) {
+                if (section.isBoolean(subsectionName)) {
+                    return new ScriptResult(section.getBoolean(subsectionName));
+                } else if (section.isInt(subsectionName)) {
+                    return new ScriptResult(section.getInt(subsectionName));
+                } else if (section.isLong(subsectionName)) {
+                    return new ScriptResult(section.getLong(subsectionName));
+                } else if (section.isDouble(subsectionName)) {
+                    return new ScriptResult(section.getDouble(subsectionName));
+                } else if (section.isString(subsectionName)) {
+                    return new ScriptResult(section.getString(subsectionName));
+                } else {
+                    return createPlantScriptSpecific(section.getConfigurationSection(subsectionName), data);
+                }
             } else {
-                return createPlantScriptSpecific(section.getConfigurationSection(subsectionName), data);
+                return null;
             }
         } catch (IllegalArgumentException e) {
             performantPlants.getLogger().warning(String.format("IllegalArgumentException loading PlantScript in section '%s' for " +
@@ -3066,13 +3071,11 @@ public class ConfigurationManager {
             return null;
         }
         for (String blockName : section.getKeys(false)) {
+            boolean directValue = false;
             ConfigurationSection blockSection = section.getConfigurationSection(blockName);
             if (blockSection == null) {
-                if (blockName.toLowerCase().equals("variable") || blockName.toLowerCase().equals("value") || blockName.toLowerCase().equals("call")) {
-                    blockSection = section;
-                } else {
-                    break;
-                }
+                blockSection = section;
+                directValue = true;
             }
             ScriptBlock returned = null;
             switch (blockName.toLowerCase()) {
@@ -3086,131 +3089,136 @@ public class ConfigurationManager {
                     returned = createScriptOperationWithNoArguments(blockSection, data); break;
                 // reference to defined stored-script-block in plant
                 case "stored":
-                    returned = getStoredScriptBlock(blockSection, data); break;
+                    returned = getStoredScriptBlock(blockSection, directValue, blockName, data); break;
                 // math
                 case "+":
                 case "add":
-                    returned = createScriptOperationAdd(blockSection, data); break;
+                    returned = createScriptOperationAdd(blockSection, directValue, data); break;
                 case "+=":
                 case "addto":
-                    returned = createScriptOperationAddTo(blockSection, data); break;
+                    returned = createScriptOperationAddTo(blockSection, directValue, data); break;
                 case "-":
                 case "subtract":
-                    returned = createScriptOperationSubtract(blockSection, data); break;
+                    returned = createScriptOperationSubtract(blockSection, directValue, data); break;
                 case "-=":
                 case "subtractfrom":
-                    returned = createScriptOperationSubtractFrom(blockSection, data); break;
+                    returned = createScriptOperationSubtractFrom(blockSection, directValue, data); break;
                 case "*":
                 case "multiply":
-                    returned = createScriptOperationMultiply(blockSection, data); break;
+                    returned = createScriptOperationMultiply(blockSection, directValue, data); break;
                 case "*=":
                 case "multiplyby":
-                    returned = createScriptOperationMultiplyBy(blockSection, data); break;
+                    returned = createScriptOperationMultiplyBy(blockSection, directValue, data); break;
                 case "/":
                 case "divide":
-                    returned = createScriptOperationDivide(blockSection, data); break;
+                    returned = createScriptOperationDivide(blockSection, directValue, data); break;
                 case "/=":
                 case "divideby":
-                    returned = createScriptOperationDivideBy(blockSection, data); break;
+                    returned = createScriptOperationDivideBy(blockSection, directValue, data); break;
                 case "%":
                 case "modulus":
-                    returned = createScriptOperationModulus(blockSection, data); break;
+                    returned = createScriptOperationModulus(blockSection, directValue, data); break;
                 case "%=":
                 case "modulusof":
-                    returned = createScriptOperationModulusOf(blockSection, data); break;
+                    returned = createScriptOperationModulusOf(blockSection, directValue, data); break;
                 case "**":
                 case "power":
-                    returned = createScriptOperationPower(blockSection, data); break;
+                    returned = createScriptOperationPower(blockSection, directValue, data); break;
                 case "**=":
                 case "powerof":
-                    returned = createScriptOperationPowerOf(blockSection, data); break;
+                    returned = createScriptOperationPowerOf(blockSection, directValue, data); break;
                 // logic
                 case "&&":
                 case "and":
-                    returned = createScriptOperationAnd(blockSection, data); break;
+                    returned = createScriptOperationAnd(blockSection, directValue, data); break;
                 case "||":
                 case "or":
-                    returned = createScriptOperationOr(blockSection, data); break;
+                    returned = createScriptOperationOr(blockSection, directValue, data); break;
                 case "!":
                 case "not":
-                    returned = createScriptOperationNot(blockSection, data); break;
+                    returned = createScriptOperationNot(blockSection, directValue, blockName, data); break;
                 // compare
                 case "==":
                 case "equal":
-                    returned = createScriptOperationEqual(blockSection, data); break;
+                case "equals":
+                    returned = createScriptOperationEqual(blockSection, directValue, data); break;
                 case "!=":
                 case "notequal":
-                    returned = createScriptOperationNotEqual(blockSection, data); break;
+                case "notequals":
+                    returned = createScriptOperationNotEqual(blockSection, directValue, data); break;
                 case ">":
                 case "greaterthan":
-                    returned = createScriptOperationGreaterThan(blockSection, data); break;
+                    returned = createScriptOperationGreaterThan(blockSection, directValue, data); break;
                 case ">=":
                 case "greaterthanorequalto":
-                    returned = createScriptOperationGreaterThanOrEqualTo(blockSection, data); break;
+                    returned = createScriptOperationGreaterThanOrEqualTo(blockSection, directValue, data); break;
                 case "<":
                 case "lessthan":
-                    returned = createScriptOperationLessThan(blockSection, data); break;
+                    returned = createScriptOperationLessThan(blockSection, directValue, data); break;
                 case "<=":
                 case "lessthanorequalto":
-                    returned = createScriptOperationLessThanOrEqualTo(blockSection, data); break;
+                    returned = createScriptOperationLessThanOrEqualTo(blockSection, directValue, data); break;
                 // cast
                 case "(boolean)":
                 case "toboolean":
-                    returned = createScriptOperationToBoolean(blockSection, data); break;
+                    returned = createScriptOperationToBoolean(blockSection, directValue, blockName, data); break;
                 case "(double)":
                 case "todouble":
-                    returned = createScriptOperationToDouble(blockSection, data); break;
+                    returned = createScriptOperationToDouble(blockSection, directValue, blockName, data); break;
                 case "(long)":
                 case "tolong":
-                    returned = createScriptOperationToLong(blockSection, data); break;
+                    returned = createScriptOperationToLong(blockSection, directValue, blockName, data); break;
                 case "(string)":
                 case "tostring":
-                    returned = createScriptOperationToString(blockSection, data); break;
+                    returned = createScriptOperationToString(blockSection, directValue, blockName, data); break;
                 // functions
                 case "contains":
-                    returned = createScriptOperationContains(blockSection, data); break;
+                    returned = createScriptOperationContains(blockSection, directValue, data); break;
                 case "length":
-                    returned = createScriptOperationLength(blockSection, data); break;
+                    returned = createScriptOperationLength(blockSection, directValue, blockName, data); break;
                 case "=":
                 case "setvalue":
-                    returned = createScriptOperationSetValue(blockSection, data); break;
+                    returned = createScriptOperationSetValue(blockSection, directValue, data); break;
                 case "setvaluescope":
                 case "setvaluescopeparameter":
-                    returned = createScriptOperationSetValueScopeParameter(blockSection, data); break;
+                    returned = createScriptOperationSetValueScopeParameter(blockSection, directValue, data); break;
                 case "getvaluescope":
                 case "getvaluescopeparameter":
-                    returned = createScriptOperationGetValueScopeParameter(blockSection, data); break;
+                    returned = createScriptOperationGetValueScopeParameter(blockSection, directValue, data); break;
                 case "removescope":
                 case "removescopeparameter":
-                    returned = createScriptOperationRemoveScopeParameter(blockSection, data); break;
+                    returned = createScriptOperationRemoveScopeParameter(blockSection, directValue, data); break;
+                case "containsscope":
+                case "containsscopeparameter":
+                    returned = createScriptOperationContainsScopeParameter(blockSection, directValue, data); break;
                 // flow
                 case "if":
-                    returned = createScriptOperationIf(blockSection, data); break;
+                    returned = createScriptOperationIf(blockSection, directValue, data); break;
                 case "func":
                 case "function":
-                    returned = createScriptOperationFunction(blockSection, data); break;
+                    returned = createScriptOperationFunction(blockSection, directValue, data); break;
                 // action
                 case "changestage":
-                    returned = createScriptOperationChangeStage(blockSection, data); break;
+                    returned = createScriptOperationChangeStage(blockSection, directValue, data); break;
                 case "interact":
-                    returned = createScriptOperationInteract(blockSection, data); break;
+                    returned = createScriptOperationInteract(blockSection, directValue, data); break;
                 case "consumable":
-                    returned = createScriptOperationConsumable(blockSection, data); break;
+                    returned = createScriptOperationConsumable(blockSection, directValue, data); break;
                 case "createblocks":
-                    returned = createScriptOperationCreatePlantBlocks(blockSection, data); break;
+                    returned = createScriptOperationCreatePlantBlocks(blockSection, directValue, data); break;
                 case "scheduletask":
-                    returned = createScriptOperationScheduleTask(blockSection, data); break;
+                    returned = createScriptOperationScheduleTask(blockSection, directValue, data); break;
                 case "canceltask":
-                    returned = createScriptOperationCancelTask(blockSection, data); break;
+                    returned = createScriptOperationCancelTask(blockSection, directValue, data); break;
                 // random
                 case "chance":
-                    returned = createScriptOperationChance(blockSection, data); break;
+                    returned = createScriptOperationChance(blockSection, directValue, blockName, data); break;
                 case "choice":
-                    returned = createScriptOperationChoice(blockSection, data); break;
+                    returned = createScriptOperationChoice(blockSection, directValue, data); break;
                 case "randomdouble":
-                    returned = createScriptOperationRandomDouble(blockSection, data); break;
+                    returned = createScriptOperationRandomDouble(blockSection, directValue, data); break;
                 case "randomlong":
-                    returned = createScriptOperationRandomLong(blockSection, data); break;
+                    returned = createScriptOperationRandomLong(blockSection, directValue, data); break;
                 // not recognized
                 default:
                     performantPlants.getLogger().warning(String.format("PlantScript block of type '%s' not recognized; this " +
@@ -3300,15 +3308,19 @@ public class ConfigurationManager {
     }
 
     // types - helpful
-    ScriptBlock createScriptOperationUnary(ConfigurationSection section, PlantData data) {
-        if (!section.isSet("input")) {
-            performantPlants.getLogger().warning("Input operand missing in section: " + section.getCurrentPath());
-            return null;
+    ScriptBlock createScriptOperationUnary(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        if (!directValue) {
+            return createPlantScript(section.getParent(), sectionName, data);
         }
-        return createPlantScript(section, "input", data);
+        return createPlantScript(section, sectionName, data);
     }
 
-    ArrayList<ScriptBlock> createScriptOperationBinary(ConfigurationSection section, PlantData data) {
+    ArrayList<ScriptBlock> createScriptOperationBinary(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationBinary in section: %s", section.getCurrentPath()));
+            return null;
+        }
         if (!section.isSet("left") || !section.isSet("right")) {
             performantPlants.getLogger().warning("Left or right operand missing in section: " + section.getCurrentPath());
             return null;
@@ -3328,11 +3340,11 @@ public class ConfigurationManager {
     }
 
     // stored script block
-    ScriptBlock getStoredScriptBlock(ConfigurationSection section, PlantData data) {
+    ScriptBlock getStoredScriptBlock(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
         if (data == null || data.getPlant() == null) {
             return null;
         }
-        ScriptBlock scriptBlockName = createScriptOperationUnary(section, data);
+        ScriptBlock scriptBlockName = createScriptOperationUnary(section, directValue, sectionName, data);
         if (scriptBlockName == null) {
             performantPlants.getLogger().warning("Name of script block name could not be parsed in section: " +
                     section.getCurrentPath());
@@ -3354,85 +3366,85 @@ public class ConfigurationManager {
     }
 
     // math
-    ScriptOperation createScriptOperationAdd(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationAdd(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationAdd(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationAddTo(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationAddTo(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationAddTo(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationSubtract(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationSubtract(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationSubtract(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationSubtractFrom(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationSubtractFrom(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationSubtractFrom(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationMultiply(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationMultiply(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationMultiply(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationMultiplyBy(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationMultiplyBy(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationMultiplyBy(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationDivide(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationDivide(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationDivide(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationDivideBy(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationDivideBy(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationDivideBy(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationModulus(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationModulus(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationModulus(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationModulusOf(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationModulusOf(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationModulusOf(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationPower(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationPower(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationPower(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationPowerOf(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationPowerOf(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
@@ -3440,22 +3452,22 @@ public class ConfigurationManager {
     }
     
     //logic
-    ScriptOperation createScriptOperationAnd(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationAnd(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationAnd(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationOr(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationOr(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationOr(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationNot(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationNot(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
@@ -3463,43 +3475,43 @@ public class ConfigurationManager {
     }
     
     //compare
-    ScriptOperation createScriptOperationEqual(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationEqual(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationEqual(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationNotEqual(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationNotEqual(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationNotEqual(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationGreaterThan(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationGreaterThan(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationGreaterThan(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationGreaterThanOrEqualTo(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationGreaterThanOrEqualTo(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationGreaterThanOrEqualTo(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationLessThan(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationLessThan(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationLessThan(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationLessThanOrEqualTo(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationLessThanOrEqualTo(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
@@ -3507,29 +3519,29 @@ public class ConfigurationManager {
     }
 
     // cast
-    ScriptOperation createScriptOperationToBoolean(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationToBoolean(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
         return new ScriptOperationToBoolean(operand);
     }
-    ScriptOperation createScriptOperationToDouble(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationToDouble(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
         return new ScriptOperationToDouble(operand);
     }
-    ScriptOperation createScriptOperationToLong(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationToLong(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
         return new ScriptOperationToLong(operand);
     }
-    ScriptOperation createScriptOperationToString(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationToString(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
@@ -3537,28 +3549,33 @@ public class ConfigurationManager {
     }
 
     // functions
-    ScriptOperation createScriptOperationContains(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationContains(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationContains(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationLength(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationLength(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
         return new ScriptOperationLength(operand);
     }
-    ScriptOperation createScriptOperationSetValue(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationSetValue(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationSetValue(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationRemoveScopeParameter(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationRemoveScopeParameter(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationRemoveScopeParameter in section: %s", section.getCurrentPath()));
+            return null;
+        }
         String plantIdString = "plant-id";
         String scopeString = "scope";
         String parameterString = "parameter";
@@ -3591,7 +3608,50 @@ public class ConfigurationManager {
         }
         return new ScriptOperationRemoveScopeParameter(plantId, scope, parameter);
     }
-    ScriptOperation createScriptOperationSetValueScopeParameter(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationContainsScopeParameter(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationContainsScopeParameter in section: %s", section.getCurrentPath()));
+            return null;
+        }
+        String plantIdString = "plant-id";
+        String scopeString = "scope";
+        String parameterString = "parameter";
+        // set plantId
+        if (!section.isSet(plantIdString)) {
+            performantPlants.getLogger().warning("plant-id operand missing in section: " + section.getCurrentPath());
+            return null;
+        }
+        ScriptBlock plantId = createPlantScript(section, plantIdString, data);
+        if (plantId == null) {
+            return null;
+        }
+        // set scope
+        if (!section.isSet(scopeString)) {
+            performantPlants.getLogger().warning("scope operand missing in section: " + section.getCurrentPath());
+            return null;
+        }
+        ScriptBlock scope = createPlantScript(section, scopeString, data);
+        if (scope == null) {
+            return null;
+        }
+        // set parameter
+        if (!section.isSet(parameterString)) {
+            performantPlants.getLogger().warning("parameter operand missing in section: " + section.getCurrentPath());
+            return null;
+        }
+        ScriptBlock parameter = createPlantScript(section, parameterString, data);
+        if (parameter == null) {
+            return null;
+        }
+        return new ScriptOperationContainsScopeParameter(plantId, scope, parameter);
+    }
+    ScriptOperation createScriptOperationSetValueScopeParameter(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationSetValueScopeParameter in section: %s", section.getCurrentPath()));
+            return null;
+        }
         String plantIdString = "plant-id";
         String scopeString = "scope";
         String parameterString = "parameter";
@@ -3644,7 +3704,12 @@ public class ConfigurationManager {
         }
         return new ScriptOperationSetValueScopeParameter(plantId, scope, parameter, variableName, value);
     }
-    ScriptOperation createScriptOperationGetValueScopeParameter(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationGetValueScopeParameter(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationGetValueScopeParameter in section: %s", section.getCurrentPath()));
+            return null;
+        }
         String plantIdString = "plant-id";
         String scopeString = "scope";
         String parameterString = "parameter";
@@ -3701,7 +3766,12 @@ public class ConfigurationManager {
     }
 
     //flow
-    ScriptOperation createScriptOperationIf(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationIf(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationIf in section: %s", section.getCurrentPath()));
+            return null;
+        }
         String conditionString = "condition";
         String ifTrueString = "if-true";
         String ifFalseString = "if-false";
@@ -3726,7 +3796,12 @@ public class ConfigurationManager {
         }
         return new ScriptOperationIf(condition, ifTrue, ifFalse);
     }
-    ScriptOperation createScriptOperationFunction(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationFunction(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationFunction in section: %s", section.getCurrentPath()));
+            return null;
+        }
         int index = 0;
         ScriptBlock[] scriptBlocks = new ScriptBlock[section.getKeys(false).size()];
         for (String placeholder : section.getKeys(false)) {
@@ -3751,7 +3826,12 @@ public class ConfigurationManager {
     }
 
     //action
-    ScriptOperation createScriptOperationInteract(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationInteract(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationInteract in section: %s", section.getCurrentPath()));
+            return null;
+        }
         PlantInteractStorage plantInteractStorage = loadPlantInteractStorage(section, data);
         if (plantInteractStorage == null) {
             performantPlants.getLogger().warning("Could not load interact section to generate PlantScript Interact in section: " +
@@ -3765,7 +3845,12 @@ public class ConfigurationManager {
         }
         return new ScriptOperationInteract(plantInteractStorage, useMainHand);
     }
-    ScriptOperation createScriptOperationConsumable(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationConsumable(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationConsumable in section: %s", section.getCurrentPath()));
+            return null;
+        }
         PlantConsumableStorage plantConsumableStorage = loadPlantConsumableStorage(section, data);
         if (plantConsumableStorage == null) {
             performantPlants.getLogger().warning("Could not load consumable section to generate PlantScript Consumable in " +
@@ -3779,7 +3864,12 @@ public class ConfigurationManager {
         }
         return new ScriptOperationConsumable(plantConsumableStorage, useMainHand);
     }
-    ScriptOperation createScriptOperationChangeStage(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationChangeStage(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationChangeStage in section: %s", section.getCurrentPath()));
+            return null;
+        }
         String stageString = "go-to-stage";
         String ifNextString = "go-to-next";
         if (!section.isSet(stageString) && !section.isSet(ifNextString)) {
@@ -3796,11 +3886,21 @@ public class ConfigurationManager {
         }
         return new ScriptOperationChangeStage(performantPlants, stage, ifNext);
     }
-    ScriptOperation createScriptOperationCreatePlantBlocks(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationCreatePlantBlocks(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationCreatePlantBlocks in section: %s", section.getCurrentPath()));
+            return null;
+        }
         // TODO: fill out
         return null;
     }
-    ScriptOperation createScriptOperationScheduleTask(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationScheduleTask(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationScheduleTask in section: %s", section.getCurrentPath()));
+            return null;
+        }
         // get task config id
         String taskConfigId = section.getString("task");
         if (taskConfigId == null || taskConfigId.isEmpty()) {
@@ -3880,7 +3980,12 @@ public class ConfigurationManager {
                 currentPlayer, currentBlock, playerId, autostart);
     }
 
-    ScriptOperation createScriptOperationCancelTask(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationCancelTask(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationCancelTask in section: %s", section.getCurrentPath()));
+            return null;
+        }
         // get task id
         ScriptBlock taskId = createPlantScript(section, "task-id", data);
         if (taskId == null || !ScriptHelper.isString(taskId)) {
@@ -3891,14 +3996,19 @@ public class ConfigurationManager {
     }
 
     //random
-    ScriptOperation createScriptOperationChance(ConfigurationSection section, PlantData data) {
-        ScriptBlock operand = createScriptOperationUnary(section, data);
+    ScriptOperation createScriptOperationChance(ConfigurationSection section, boolean directValue, String sectionName, PlantData data) {
+        ScriptBlock operand = createScriptOperationUnary(section, directValue, sectionName, data);
         if (operand == null) {
             return null;
         }
         return new ScriptOperationChance(operand);
     }
-    ScriptOperation createScriptOperationChoice(ConfigurationSection section, PlantData data) {
+    ScriptOperation createScriptOperationChoice(ConfigurationSection section, boolean directValue, PlantData data) {
+        if (directValue) {
+            performantPlants.getLogger().warning(String.format("DirectValue section not supported in " +
+                    "ScriptOperationChoice in section: %s", section.getCurrentPath()));
+            return null;
+        }
         int index = 0;
         ScriptBlock[] scriptBlocks = new ScriptBlock[section.getKeys(false).size()];
         for (String placeholder : section.getKeys(false)) {
@@ -3921,15 +4031,15 @@ public class ConfigurationManager {
         }
         return new ScriptOperationChoice(scriptBlocks);
     }
-    ScriptOperation createScriptOperationRandomDouble(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationRandomDouble(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }
         return new ScriptOperationRandomDouble(operands.get(0), operands.get(1));
     }
-    ScriptOperation createScriptOperationRandomLong(ConfigurationSection section, PlantData data) {
-        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, data);
+    ScriptOperation createScriptOperationRandomLong(ConfigurationSection section, boolean directValue, PlantData data) {
+        ArrayList<ScriptBlock> operands = createScriptOperationBinary(section, directValue, data);
         if (operands == null) {
             return null;
         }

--- a/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
@@ -2920,6 +2920,8 @@ public class ConfigurationManager {
                         type, hookSection.getCurrentPath()));
                 return null;
         }
+        // set script block + config id, if applicable
+        scriptHook = createPlantScriptHookScriptBlockAndConfigId(scriptHook, action, hookSection, data);
         return scriptHook;
     }
 
@@ -2956,6 +2958,22 @@ public class ConfigurationManager {
             return null;
         }
         return playerHookInputs;
+    }
+
+    ScriptHook createPlantScriptHookScriptBlockAndConfigId(ScriptHook hook, HookAction action, ConfigurationSection section, PlantData data) {
+        if (hook == null) {
+            return null;
+        }
+        if (section.isSet("plant-script")) {
+            ScriptBlock scriptBlock = createPlantScript(section, "plant-script", data);
+            if (scriptBlock == null) {
+                main.getLogger().warning("Plant-script section is not valid plant script block in section: " + section.getCurrentPath());
+                return null;
+            }
+            hook.setHookConfigId(action.toString() + "." + section.getName());
+            hook.setHookScriptBlock(scriptBlock);
+        }
+        return hook;
     }
 
     ScriptHookPlayerAlive createPlantScriptHookPlayerAlive(HookAction action, ScriptTask task, ConfigurationSection section, PlantData data) {

--- a/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/ConfigurationManager.java
@@ -2838,7 +2838,7 @@ public class ConfigurationManager {
     //region Plant Script Hooks
     ArrayList<ScriptHook> createPlantScriptHooks(ScriptTask scriptTask, ConfigurationSection section, String subsectionName, PlantData data) {
         // if section exists
-        ArrayList<ScriptHook> hooks = new ArrayList<ScriptHook>();
+        ArrayList<ScriptHook> hooks = new ArrayList<>();
         if (section.isSet(subsectionName)) {
             ConfigurationSection hooksSection = section.getConfigurationSection(subsectionName);
             // create hooks with START action
@@ -2961,9 +2961,9 @@ public class ConfigurationManager {
                 performantPlants.getLogger().warning("Plant-script section is not valid plant script block in section: " + section.getCurrentPath());
                 return null;
             }
-            hook.setHookConfigId(action.toString() + "." + section.getName());
             hook.setHookScriptBlock(scriptBlock);
         }
+        hook.setHookConfigId(action.toString() + "." + section.getName());
         return hook;
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/managers/DatabaseManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/DatabaseManager.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 public class DatabaseManager {
 
     private final PerformantPlants performantPlants;
-    private String storageDir = "storage/";
+    private final String storageDir = "storage/";
     private final HashMap<String, File> databaseFiles = new HashMap<>();
     private File statisticsDatabaseFile;
     private File globalDataDatabaseFile;

--- a/src/main/java/me/kosinkadink/performantplants/managers/PlantManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/PlantManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.chunks.PlantChunk;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -15,17 +15,17 @@ import java.util.HashMap;
 
 public class PlantManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
     private static HashMap<String, PlantChunkStorage> plantChunkStorageMap = new HashMap<>();
 
-    public PlantManager(Main mainClass) {
-        main = mainClass;
+    public PlantManager(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
         createPlantChunkStorageMap();
     }
 
     public void createPlantChunkStorageMap() {
         for (World world : Bukkit.getWorlds()) {
-            PlantChunkStorage plantChunkStorage = new PlantChunkStorage(main, world.getName());
+            PlantChunkStorage plantChunkStorage = new PlantChunkStorage(performantPlants, world.getName());
             addPlantChunkStorage(plantChunkStorage);
         }
     }
@@ -53,7 +53,7 @@ public class PlantManager {
         // get plantChunkStorage
         PlantChunkStorage plantChunkStorage = getPlantChunkStorage(chunkLocation);
         if (plantChunkStorage == null) {
-            plantChunkStorage = new PlantChunkStorage(main, chunkLocation.getWorldName());
+            plantChunkStorage = new PlantChunkStorage(performantPlants, chunkLocation.getWorldName());
             addPlantChunkStorage(plantChunkStorage);
         }
         plantChunkStorage.addPlantBlock(block);
@@ -81,7 +81,7 @@ public class PlantManager {
                 parent.removeChildLocation(block.getLocation());
                 // if parent's stage should be updated, do it
                 if (block.isUpdateStageOnBreak()) {
-                    parent.goToPreviousStageGracefully(main, block.getStageIndex());
+                    parent.goToPreviousStageGracefully(performantPlants, block.getStageIndex());
                 }
             }
         }
@@ -137,7 +137,7 @@ public class PlantManager {
     //region Task Control
 
     public void startGrowthTask(PlantBlock plantBlock) {
-        plantBlock.startTask(main);
+        plantBlock.startTask(performantPlants);
     }
 
     public void startGrowthTask(BlockLocation blockLocation) {
@@ -159,7 +159,7 @@ public class PlantManager {
     }
 
     public void setGrowthTaskStage(PlantBlock plantBlock, int stage) {
-        plantBlock.goToPreviousStageGracefully(main, stage);
+        plantBlock.goToPreviousStageGracefully(performantPlants, stage);
     }
 
     public void setGrowthTaskStage(BlockLocation blockLocation, int stage) {

--- a/src/main/java/me/kosinkadink/performantplants/managers/PlantTypeManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/PlantTypeManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.builders.PlantItemBuilder;
 import me.kosinkadink.performantplants.plants.Plant;
 import me.kosinkadink.performantplants.plants.PlantItem;
@@ -11,12 +11,12 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class PlantTypeManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
     private final ConcurrentHashMap<String, Plant> plantTypeMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, PlantDataStorage> plantDataStorageMap = new ConcurrentHashMap<>();
 
-    public PlantTypeManager(Main mainClass) {
-        main = mainClass;
+    public PlantTypeManager(PerformantPlants performantPlantsClass) {
+        performantPlants = performantPlantsClass;
     }
 
     void addPlantDataStorage(PlantDataStorage storage) {
@@ -43,6 +43,14 @@ public class PlantTypeManager {
         PlantDataStorage plantDataStorage = getPlantDataStorage(plantId);
         if (plantDataStorage != null) {
             return plantDataStorage.updateVariable(scope, parameter, variableName, value);
+        }
+        return false;
+    }
+
+    public boolean removeScopeParameter(String plantId, String scope, String parameter) {
+        PlantDataStorage plantDataStorage = getPlantDataStorage(plantId);
+        if (plantDataStorage != null) {
+            return plantDataStorage.removeScopeParameter(scope, parameter);
         }
         return false;
     }

--- a/src/main/java/me/kosinkadink/performantplants/managers/PlantTypeManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/PlantTypeManager.java
@@ -47,6 +47,14 @@ public class PlantTypeManager {
         return false;
     }
 
+    public boolean containsScopeParameter(String plantId, String scope, String parameter) {
+        PlantDataStorage plantDataStorage = getPlantDataStorage(plantId);
+        if (plantDataStorage != null) {
+            return plantDataStorage.containsScopeParameter(scope, parameter);
+        }
+        return false;
+    }
+
     public boolean removeScopeParameter(String plantId, String scope, String parameter) {
         PlantDataStorage plantDataStorage = getPlantDataStorage(plantId);
         if (plantDataStorage != null) {

--- a/src/main/java/me/kosinkadink/performantplants/managers/RecipeManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/RecipeManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.PlantRecipe;
 import org.bukkit.inventory.*;
 
@@ -8,7 +8,7 @@ import java.util.HashMap;
 
 public class RecipeManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private HashMap<String, PlantRecipe> shapedRecipeMap = new HashMap<>();
     private HashMap<String, PlantRecipe> shapelessRecipeMap = new HashMap<>();
@@ -18,8 +18,8 @@ public class RecipeManager {
     private HashMap<String, CampfireRecipe> campfireRecipeMap = new HashMap<>();
     private HashMap<String, StonecuttingRecipe> stonecuttingRecipeMap = new HashMap<>();
 
-    public RecipeManager(Main main) {
-        this.main = main;
+    public RecipeManager(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     public boolean isRecipe(Recipe recipe) {
@@ -138,25 +138,25 @@ public class RecipeManager {
     private void clearRecipe(Recipe recipe) {
         if (recipe instanceof ShapedRecipe) {
             ShapedRecipe convertedRecipe = (ShapedRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof ShapelessRecipe) {
             ShapelessRecipe convertedRecipe = (ShapelessRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof FurnaceRecipe) {
             FurnaceRecipe convertedRecipe = (FurnaceRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof BlastingRecipe) {
             BlastingRecipe convertedRecipe = (BlastingRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof SmokingRecipe) {
             SmokingRecipe convertedRecipe = (SmokingRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof CampfireRecipe) {
             CampfireRecipe convertedRecipe = (CampfireRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         } else if (recipe instanceof StonecuttingRecipe) {
             StonecuttingRecipe convertedRecipe = (StonecuttingRecipe) recipe;
-            main.getServer().removeRecipe(convertedRecipe.getKey());
+            performantPlants.getServer().removeRecipe(convertedRecipe.getKey());
         }
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/managers/StatisticsManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/StatisticsManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.statistics.StatisticsAmount;
 import me.kosinkadink.performantplants.statistics.StatisticsTagItem;
 import me.kosinkadink.performantplants.storage.StatisticsAmountStorage;
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class StatisticsManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private ConcurrentHashMap<UUID, StatisticsAmountStorage> plantItemsSoldStorageMap = new ConcurrentHashMap<>();
     private HashSet<StatisticsAmount> statisticsAmountsToDelete = new HashSet<>();
@@ -22,8 +22,8 @@ public class StatisticsManager {
     private ConcurrentHashMap<String, StatisticsTagStorage> plantTagStorageMap = new ConcurrentHashMap<>();
     private HashSet<StatisticsTagItem> statisticsTagsToDeleteItem = new HashSet<>();
 
-    public StatisticsManager(Main main) {
-        this.main = main;
+    public StatisticsManager(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     // region PlantItemsSold

--- a/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class TaskManager {
 
-    private Main main;
+    private final Main main;
 
     private final ConcurrentHashMap<String, PlantTask> taskMap = new ConcurrentHashMap<>();
     private final HashSet<UUID> taskIdsToDelete = new HashSet<>();

--- a/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
@@ -1,7 +1,9 @@
 package me.kosinkadink.performantplants.managers;
 
 import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.hooks.*;
 import me.kosinkadink.performantplants.tasks.PlantTask;
+import org.bukkit.entity.Player;
 
 import java.util.HashSet;
 import java.util.UUID;
@@ -14,15 +16,56 @@ public class TaskManager {
     private final ConcurrentHashMap<String, PlantTask> taskMap = new ConcurrentHashMap<>();
     private final HashSet<UUID> taskIdsToDelete = new HashSet<>();
 
+    // hook mapping
+    // player hooks; map PlayerUUID to a set of PlantHook ids in hookMap
+    private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerOnlineMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerOfflineMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerAliveMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerDeadMap = new ConcurrentHashMap<>();
+
     public TaskManager(Main main) {
         this.main = main;
     }
 
     public boolean scheduleTask(PlantTask task) {
-        boolean startedTask = task.startTask(main);
-        if (startedTask) {
+        if (task.isStartable()) {
+            if (main.getConfigManager().getConfigSettings().isDebug()) {
+                main.getLogger().info("Scheduling task with id: " + task.getTaskId());
+            }
             addTaskToMap(task);
+            // if autostart, then start task
+            if (task.isAutostart()) {
+                boolean startedTask = task.startTask(main);
+                // if failed to start, cancel task and return false
+                if (!startedTask) {
+                    cancelTask(task.getTaskId().toString());
+                    return false;
+                }
+            } else {
+                // otherwise pause it
+                task.pauseTask();
+            }
+            // check hooks
+            for (PlantHook hook : task.getHooks()) {
+                // if performStartup results in a cancel action (returned false), return false since it got cancelled
+                if (!hook.performStartup()) {
+                    return false;
+                }
+                // register hook
+                registerHook(hook);
+            }
             return true;
+        }
+        return false;
+    }
+
+    public boolean resumeTask(String taskId) {
+        PlantTask plantTask = getTask(taskId);
+        if (plantTask != null) {
+            if (main.getConfigManager().getConfigSettings().isDebug()) {
+                main.getLogger().info("Resuming task with id: " + taskId);
+            }
+            return plantTask.startTask(main);
         }
         return false;
     }
@@ -36,6 +79,9 @@ public class TaskManager {
     public boolean pauseTask(String taskId) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
+            if (main.getConfigManager().getConfigSettings().isDebug()) {
+                main.getLogger().info("Pausing task with id: " + taskId);
+            }
             plantTask.pauseTask();
             return true;
         }
@@ -45,12 +91,170 @@ public class TaskManager {
     public boolean cancelTask(String taskId) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
+            if (main.getConfigManager().getConfigSettings().isDebug()) {
+                main.getLogger().info("Cancelling task with id: " + taskId);
+            }
             plantTask.cancelTask();
             removeTaskId(taskId);
             return true;
         }
         return false;
     }
+
+    public void freezeAllTasks() {
+        for (PlantTask plantTask : taskMap.values()) {
+            plantTask.freezeTask();
+        }
+    }
+
+    public boolean freezeTask(String taskId) {
+        PlantTask plantTask = getTask(taskId);
+        if (plantTask != null) {
+            plantTask.freezeTask();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean unfreezeTask(String taskId) {
+        PlantTask plantTask = getTask(taskId);
+        if (plantTask != null) {
+            plantTask.unfreezeTask(main);
+            return true;
+        }
+        return false;
+    }
+
+    public void removeTaskIdFromRemoval(UUID taskId) {
+        taskIdsToDelete.remove(taskId);
+    }
+
+    public HashSet<UUID> getTaskIdsToDelete() {
+        return taskIdsToDelete;
+    }
+
+    //region Hook Triggers
+    public boolean triggerPlayerAliveHooks(Player player) {
+        HashSet<PlantHook> hookIdSet = hookPlayerAliveMap.get(player.getUniqueId().toString());
+        if (hookIdSet == null || hookIdSet.isEmpty()) {
+            return false;
+        }
+        return performHooks(hookIdSet);
+    }
+
+    public boolean triggerPlayerDeadHooks(Player player) {
+        HashSet<PlantHook> hookIdSet = hookPlayerDeadMap.get(player.getUniqueId().toString());
+        if (hookIdSet == null || hookIdSet.isEmpty()) {
+            return false;
+        }
+        return performHooks(hookIdSet);
+    }
+
+    public boolean triggerPlayerOnlineHooks(Player player) {
+        HashSet<PlantHook> hookIdSet = hookPlayerOnlineMap.get(player.getUniqueId().toString());
+        if (hookIdSet == null || hookIdSet.isEmpty()) {
+            return false;
+        }
+        return performHooks(hookIdSet);
+    }
+
+    public boolean triggerPlayerOfflineHooks(Player player) {
+        HashSet<PlantHook> hookIdSet = hookPlayerOfflineMap.get(player.getUniqueId().toString());
+        if (hookIdSet == null || hookIdSet.isEmpty()) {
+            return false;
+        }
+        return performHooks(hookIdSet);
+    }
+
+    private boolean performHooks(HashSet<PlantHook> hookIdSet) {
+        for (PlantHook hook : hookIdSet) {
+            switch(hook.getAction()) {
+                case START:
+                    return resumeTask(hook.getTaskId().toString());
+                case PAUSE:
+                    return pauseTask(hook.getTaskId().toString());
+                case CANCEL:
+                    return cancelTask(hook.getTaskId().toString());
+            }
+        }
+        return true;
+    }
+    //endregion
+
+    //region Hook Register/Unregister
+    public boolean registerHook(PlantHook hook) {
+        if (hook != null) {
+            ConcurrentHashMap<String, HashSet<PlantHook>> plantHookMap = null;
+            // player hooks
+            if (hook instanceof PlantHookPlayer) {
+                PlantHookPlayer hookPlayer = (PlantHookPlayer) hook;
+                plantHookMap = getMatchingPlayerHookMap(hookPlayer);
+                if (plantHookMap != null) {
+                    return addHookToMap(hookPlayer, plantHookMap);
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean unregisterHook(PlantHook hook) {
+        if (hook != null) {
+            ConcurrentHashMap<String, HashSet<PlantHook>> plantHookMap = null;
+            // player hooks
+            if (hook instanceof PlantHookPlayer) {
+                PlantHookPlayer hookPlayer = (PlantHookPlayer) hook;
+                plantHookMap = getMatchingPlayerHookMap(hookPlayer);
+                // if recognized, get HashSet and remove hook
+                if (plantHookMap != null) {
+                    HashSet<PlantHook> hookHashSet = plantHookMap.get(hookPlayer.getOfflinePlayer().getUniqueId().toString());
+                    if (hookHashSet != null) {
+                        return hookHashSet.remove(hook);
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean addHookToMap(PlantHook hook, ConcurrentHashMap<String, HashSet<PlantHook>> plantHookMap) {
+        if (hook == null || plantHookMap == null) {
+            return false;
+        }
+        // get hook input corresponding to hook type
+        String hookInput = null;
+        if (hook instanceof PlantHookPlayer) {
+            hookInput = ((PlantHookPlayer) hook).getOfflinePlayer().getUniqueId().toString();
+        }
+        if (hookInput == null) {
+            return false;
+        }
+        // see if HashSet bound to hook input already exists
+        HashSet<PlantHook> hookHashSet = plantHookMap.get(hookInput);
+        if (hookHashSet != null) {
+            hookHashSet.add(hook);
+        } else {
+            hookHashSet = new HashSet<>();
+            hookHashSet.add(hook);
+            plantHookMap.put(hookInput, hookHashSet);
+        }
+        return true;
+    }
+
+    private ConcurrentHashMap<String, HashSet<PlantHook>> getMatchingPlayerHookMap(PlantHookPlayer hook) {
+        ConcurrentHashMap<String, HashSet<PlantHook>> plantHookMap = null;
+        // figure out which type of player hook it is
+        if (hook instanceof PlantHookPlayerOnline) {
+            plantHookMap = hookPlayerOnlineMap;
+        } else if (hook instanceof PlantHookPlayerOffline) {
+            plantHookMap = hookPlayerOfflineMap;
+        } else if (hook instanceof PlantHookPlayerAlive) {
+            plantHookMap = hookPlayerAliveMap;
+        } else if (hook instanceof PlantHookPlayerDead) {
+            plantHookMap = hookPlayerDeadMap;
+        }
+        return plantHookMap;
+    }
+    //endregion
 
     private PlantTask getTask(String taskId) {
         return taskMap.get(taskId);
@@ -66,16 +270,12 @@ public class TaskManager {
         if (plantTask == null) {
             return false;
         }
+        // unregister hooks
+        for (PlantHook hook : plantTask.getHooks()) {
+            unregisterHook(hook);
+        }
         taskIdsToDelete.add(plantTask.getTaskId());
         return true;
-    }
-
-    public void removeTaskIdFromRemoval(UUID taskId) {
-        taskIdsToDelete.remove(taskId);
-    }
-
-    public HashSet<UUID> getTaskIdsToDelete() {
-        return taskIdsToDelete;
     }
 
 }

--- a/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
@@ -1,0 +1,81 @@
+package me.kosinkadink.performantplants.managers;
+
+import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.tasks.PlantTask;
+
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TaskManager {
+
+    private Main main;
+
+    private final ConcurrentHashMap<String, PlantTask> taskMap = new ConcurrentHashMap<>();
+    private final HashSet<UUID> taskIdsToDelete = new HashSet<>();
+
+    public TaskManager(Main main) {
+        this.main = main;
+    }
+
+    public boolean scheduleTask(PlantTask task) {
+        boolean startedTask = task.startTask(main);
+        if (startedTask) {
+            addTaskToMap(task);
+            return true;
+        }
+        return false;
+    }
+
+    public void pauseAllTasks() {
+        for (PlantTask plantTask : taskMap.values()) {
+            plantTask.pauseTask();
+        }
+    }
+
+    public boolean pauseTask(String taskId) {
+        PlantTask plantTask = getTask(taskId);
+        if (plantTask != null) {
+            plantTask.pauseTask();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean cancelTask(String taskId) {
+        PlantTask plantTask = getTask(taskId);
+        if (plantTask != null) {
+            plantTask.cancelTask();
+            removeTaskId(taskId);
+            return true;
+        }
+        return false;
+    }
+
+    private PlantTask getTask(String taskId) {
+        return taskMap.get(taskId);
+    }
+
+    private void addTaskToMap(PlantTask task) {
+        taskMap.put(task.getTaskId().toString(), task);
+        removeTaskIdFromRemoval(task.getTaskId());
+    }
+
+    private boolean removeTaskId(String taskId) {
+        PlantTask plantTask = taskMap.remove(taskId);
+        if (plantTask == null) {
+            return false;
+        }
+        taskIdsToDelete.add(plantTask.getTaskId());
+        return true;
+    }
+
+    public void removeTaskIdFromRemoval(UUID taskId) {
+        taskIdsToDelete.remove(taskId);
+    }
+
+    public HashSet<UUID> getTaskIdsToDelete() {
+        return taskIdsToDelete;
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/TaskManager.java
@@ -1,8 +1,7 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.hooks.*;
-import me.kosinkadink.performantplants.scripting.storage.hooks.ScriptHook;
 import me.kosinkadink.performantplants.tasks.PlantTask;
 import org.bukkit.entity.Player;
 
@@ -12,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class TaskManager {
 
-    private final Main main;
+    private final PerformantPlants performantPlants;
 
     private final ConcurrentHashMap<String, PlantTask> taskMap = new ConcurrentHashMap<>();
     private final HashSet<UUID> taskIdsToDelete = new HashSet<>();
@@ -24,19 +23,19 @@ public class TaskManager {
     private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerAliveMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, HashSet<PlantHook>> hookPlayerDeadMap = new ConcurrentHashMap<>();
 
-    public TaskManager(Main main) {
-        this.main = main;
+    public TaskManager(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     public boolean scheduleTask(PlantTask task) {
         if (task.isStartable()) {
-            if (main.getConfigManager().getConfigSettings().isDebug()) {
-                main.getLogger().info("Scheduling task with id: " + task.getTaskId());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) {
+                performantPlants.getLogger().info("Scheduling task with id: " + task.getTaskId());
             }
             addTaskToMap(task);
             // if autostart, then start task
             if (task.isAutostart()) {
-                boolean startedTask = task.startTask(main);
+                boolean startedTask = task.startTask(performantPlants);
                 // if failed to start, cancel task and return false
                 if (!startedTask) {
                     cancelTask(task.getTaskId().toString(), null);
@@ -63,10 +62,10 @@ public class TaskManager {
     public boolean resumeTask(String taskId, PlantHook hook) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
-            if (main.getConfigManager().getConfigSettings().isDebug()) {
-                main.getLogger().info("Resuming task with id: " + taskId);
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) {
+                performantPlants.getLogger().info("Resuming task with id: " + taskId);
             }
-            boolean started = plantTask.startTask(main);
+            boolean started = plantTask.startTask(performantPlants);
             if (started) {
                 // perform hook script block
                 performHookScriptBlock(hook, plantTask);
@@ -85,8 +84,8 @@ public class TaskManager {
     public boolean pauseTask(String taskId, PlantHook hook) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
-            if (main.getConfigManager().getConfigSettings().isDebug()) {
-                main.getLogger().info("Pausing task with id: " + taskId);
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) {
+                performantPlants.getLogger().info("Pausing task with id: " + taskId);
             }
             boolean paused = plantTask.pauseTask();
             if (paused) {
@@ -101,8 +100,8 @@ public class TaskManager {
     public boolean cancelTask(String taskId, PlantHook hook) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
-            if (main.getConfigManager().getConfigSettings().isDebug()) {
-                main.getLogger().info("Cancelling task with id: " + taskId);
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) {
+                performantPlants.getLogger().info("Cancelling task with id: " + taskId);
             }
             boolean cancelled = plantTask.cancelTask();
             if (cancelled) {
@@ -134,7 +133,7 @@ public class TaskManager {
     public boolean unfreezeTask(String taskId) {
         PlantTask plantTask = getTask(taskId);
         if (plantTask != null) {
-            plantTask.unfreezeTask(main);
+            plantTask.unfreezeTask(performantPlants);
             return true;
         }
         return false;

--- a/src/main/java/me/kosinkadink/performantplants/managers/VanillaDropManager.java
+++ b/src/main/java/me/kosinkadink/performantplants/managers/VanillaDropManager.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.managers;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.storage.PlantInteractStorage;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -10,13 +10,13 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class VanillaDropManager {
 
-    private Main main;
+    private PerformantPlants performantPlants;
 
     private ConcurrentHashMap<Material, PlantInteractStorage> blockDropInteractMap = new ConcurrentHashMap<>();
     private ConcurrentHashMap<EntityType, PlantInteractStorage> entityDropInteractMap = new ConcurrentHashMap<>();
 
-    public VanillaDropManager(Main main) {
-        this.main = main;
+    public VanillaDropManager(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     public PlantInteractStorage getInteract(Block block) {

--- a/src/main/java/me/kosinkadink/performantplants/plants/Plant.java
+++ b/src/main/java/me/kosinkadink/performantplants/plants/Plant.java
@@ -10,6 +10,7 @@ import me.kosinkadink.performantplants.storage.RequirementStorage;
 import me.kosinkadink.performantplants.storage.StageStorage;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.json.simple.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +39,8 @@ public class Plant {
         this.id = id;
         this.plantItem = plantItem;
         this.plantItem.setId(this.id);
+        plantData = new PlantData(new JSONObject());
+        plantData.setPlant(this);
     }
 
     public String getId() {
@@ -129,6 +132,10 @@ public class Plant {
         scriptBlockMap.put(blockId, scriptBlock);
     }
 
+    public void removeAllScriptBlocks() {
+        scriptBlockMap.clear();
+    }
+
     // plant task map
     public ScriptTask getScriptTask(String taskId) {
         return scriptTaskMap.get(taskId);
@@ -201,7 +208,7 @@ public class Plant {
     //endregion
 
     public boolean hasPlantData() {
-        return plantData != null;
+        return plantData != null && !plantData.getData().isEmpty();
     }
 
     public boolean hasSeed() {

--- a/src/main/java/me/kosinkadink/performantplants/plants/Plant.java
+++ b/src/main/java/me/kosinkadink/performantplants/plants/Plant.java
@@ -3,8 +3,8 @@ package me.kosinkadink.performantplants.plants;
 import me.kosinkadink.performantplants.blocks.GrowthStageBlock;
 import me.kosinkadink.performantplants.scripting.PlantData;
 import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
 import me.kosinkadink.performantplants.stages.GrowthStage;
-import me.kosinkadink.performantplants.storage.DropStorage;
 import me.kosinkadink.performantplants.storage.PlantInteractStorage;
 import me.kosinkadink.performantplants.storage.RequirementStorage;
 import me.kosinkadink.performantplants.storage.StageStorage;
@@ -17,13 +17,14 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class Plant {
 
-    private String id;
-    private PlantItem plantItem;
+    private final String id;
+    private final PlantItem plantItem;
     private PlantItem plantSeedItem;
-    private HashMap<String, PlantItem> goods = new HashMap<>();
-    private HashMap<String, GrowthStageBlock> growthStageBlockMap = new HashMap<>();
-    private HashMap<String, ScriptBlock> scriptBlockMap = new HashMap<>();
-    private StageStorage stageStorage = new StageStorage();
+    private final HashMap<String, PlantItem> goods = new HashMap<>();
+    private final HashMap<String, GrowthStageBlock> growthStageBlockMap = new HashMap<>();
+    private final HashMap<String, ScriptBlock> scriptBlockMap = new HashMap<>();
+    private final HashMap<String, ScriptTask> scriptTaskMap = new HashMap<>();
+    private final StageStorage stageStorage = new StageStorage();
     private PlantData plantData;
     // growth requirements
     private RequirementStorage plantRequirementStorage = new RequirementStorage();
@@ -126,6 +127,15 @@ public class Plant {
 
     public void addScriptBlock(String blockId, ScriptBlock scriptBlock) {
         scriptBlockMap.put(blockId, scriptBlock);
+    }
+
+    // plant task map
+    public ScriptTask getScriptTask(String taskId) {
+        return scriptTaskMap.get(taskId);
+    }
+
+    public void addScriptTask(String taskId, ScriptTask scriptTask) {
+        scriptTaskMap.put(taskId, scriptTask);
     }
 
     // requirements

--- a/src/main/java/me/kosinkadink/performantplants/plants/PlantConsumable.java
+++ b/src/main/java/me/kosinkadink/performantplants/plants/PlantConsumable.java
@@ -12,9 +12,14 @@ public class PlantConsumable {
     private boolean missingFood = false;
     private boolean normalEat = true;
     private int addDamage = 0;
-    private ArrayList<ItemStack> itemsToGive = new ArrayList<>();
-    private ArrayList<RequiredItem> requiredItems = new ArrayList<>();
-    private PlantEffectStorage effectStorage = new PlantEffectStorage();
+    private final ArrayList<ItemStack> itemsToGive = new ArrayList<>();
+    private final ArrayList<RequiredItem> requiredItems = new ArrayList<>();
+    private final PlantEffectStorage effectStorage = new PlantEffectStorage();
+
+    private ScriptBlock doIf;
+    private ScriptBlock scriptBlock;
+    private ScriptBlock scriptBlockOnDo;
+    private ScriptBlock scriptBlockOnNotDo;
 
     public PlantConsumable() { }
 
@@ -70,4 +75,36 @@ public class PlantConsumable {
         return effectStorage;
     }
 
+    // script blocks
+    public ScriptBlock getDoIf() {
+        return doIf;
+    }
+
+    public void setDoIf(ScriptBlock doIf) {
+        this.doIf = doIf;
+    }
+
+    public ScriptBlock getScriptBlock() {
+        return scriptBlock;
+    }
+
+    public void setScriptBlock(ScriptBlock scriptBlock) {
+        this.scriptBlock = scriptBlock;
+    }
+
+    public ScriptBlock getScriptBlockOnDo() {
+        return scriptBlockOnDo;
+    }
+
+    public void setScriptBlockOnDo(ScriptBlock scriptBlockOnDo) {
+        this.scriptBlockOnDo = scriptBlockOnDo;
+    }
+
+    public ScriptBlock getScriptBlockOnNotDo() {
+        return scriptBlockOnNotDo;
+    }
+
+    public void setScriptBlockOnNotDo(ScriptBlock scriptBlockOnNotDo) {
+        this.scriptBlockOnNotDo = scriptBlockOnNotDo;
+    }
 }

--- a/src/main/java/me/kosinkadink/performantplants/plants/PlantInteract.java
+++ b/src/main/java/me/kosinkadink/performantplants/plants/PlantInteract.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class PlantInteract {
 
-    private ScriptBlock giveBlockDrops = ScriptResult.FALSE;
+    private ScriptBlock giveBlockDrops = ScriptResult.NULL; // defaults to false from getter
     private ScriptBlock doIf;
     private ScriptBlock takeItem = ScriptResult.FALSE;
     private ScriptBlock onlyTakeItemOnDo = ScriptResult.FALSE;
@@ -75,11 +75,15 @@ public class PlantInteract {
 
     // block drops
     public boolean isGiveBlockDrops(Player player, PlantBlock plantBlock) {
-        return giveBlockDrops.loadValue(plantBlock, player).getBooleanValue();
+        return isGiveBlockDropsNull() ? false : giveBlockDrops.loadValue(plantBlock, player).getBooleanValue();
     }
 
     public void setGiveBlockDrops(ScriptBlock giveBlockDrops) {
         this.giveBlockDrops = giveBlockDrops;
+    }
+
+    public boolean isGiveBlockDropsNull() {
+        return giveBlockDrops == ScriptResult.NULL;
     }
 
     public boolean isOnlyDropOnDo(Player player, PlantBlock plantBlock) {

--- a/src/main/java/me/kosinkadink/performantplants/scripting/PlantData.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/PlantData.java
@@ -61,7 +61,7 @@ public class PlantData {
             if (!data.containsKey(key)) {
                 return false;
             }
-            if (data.get(key) != otherPlantData.data.get(key)) {
+            if (!data.get(key).equals(otherPlantData.data.get(key))) {
                 return false;
             }
         }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/ScriptOperation.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/ScriptOperation.java
@@ -25,7 +25,7 @@ public abstract class ScriptOperation extends ScriptBlock {
     @Override
     public boolean containsVariable() {
         for (ScriptBlock input : inputs) {
-            if (input.containsVariable()) {
+            if (input.containsVariable() || !input.shouldOptimize()) {
                 return true;
             }
         }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
@@ -22,7 +22,7 @@ public class ScriptOperationCancelTask extends ScriptOperation {
             return ScriptResult.FALSE;
         }
         // return whether cancellation was successful
-        return new ScriptResult(Main.getInstance().getTaskManager().cancelTask(taskId));
+        return new ScriptResult(Main.getInstance().getTaskManager().cancelTask(taskId, null));
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.scripting.operations.action;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.scripting.*;
 import org.bukkit.entity.Player;
@@ -22,7 +22,7 @@ public class ScriptOperationCancelTask extends ScriptOperation {
             return ScriptResult.FALSE;
         }
         // return whether cancellation was successful
-        return new ScriptResult(Main.getInstance().getTaskManager().cancelTask(taskId, null));
+        return new ScriptResult(PerformantPlants.getInstance().getTaskManager().cancelTask(taskId, null));
     }
 
     @Override

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCancelTask.java
@@ -1,0 +1,47 @@
+package me.kosinkadink.performantplants.scripting.operations.action;
+
+import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.*;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationCancelTask extends ScriptOperation {
+
+    public ScriptOperationCancelTask(ScriptBlock taskId) {
+        super(taskId);
+    }
+
+    public ScriptBlock getTaskId() {
+        return inputs[0];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        String taskId = getTaskId().loadValue(plantBlock, player).getStringValue();
+        if (taskId.isEmpty()) {
+            return ScriptResult.FALSE;
+        }
+        // return whether cancellation was successful
+        return new ScriptResult(Main.getInstance().getTaskManager().cancelTask(taskId));
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.BOOLEAN;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.ACTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationChangeStage.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationChangeStage.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.scripting.operations.action;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.scripting.*;
 import me.kosinkadink.performantplants.storage.StageStorage;
@@ -8,11 +8,11 @@ import org.bukkit.entity.Player;
 
 public class ScriptOperationChangeStage extends ScriptOperation {
 
-    Main main;
+    PerformantPlants performantPlants;
 
-    public ScriptOperationChangeStage(Main main, ScriptBlock stage, ScriptBlock ifNext) {
+    public ScriptOperationChangeStage(PerformantPlants performantPlants, ScriptBlock stage, ScriptBlock ifNext) {
         super(stage, ifNext);
-        this.main = main;
+        this.performantPlants = performantPlants;
     }
 
     public ScriptBlock getStage() {
@@ -39,15 +39,15 @@ public class ScriptOperationChangeStage extends ScriptOperation {
             StageStorage stageStorage = effectivePlantBlock.getPlant().getStageStorage();
             if (stageStorage.isValidStage(stageName)) {
                 int stageIndex = stageStorage.getGrowthStageIndex(stageName);
-                success = effectivePlantBlock.goToStageForcefully(main, stageIndex);
+                success = effectivePlantBlock.goToStageForcefully(performantPlants, stageIndex);
             } else {
-                main.getLogger().warning(String.format("OperationChangeStage: stage name '%s' not recognized for " +
+                performantPlants.getLogger().warning(String.format("OperationChangeStage: stage name '%s' not recognized for " +
                         "block: %s", stageName, plantBlock.toString()));
             }
         }
         // if goToNext is set to true, then advance to next growth stage as if plant grew
         else if (ifNext) {
-            success = effectivePlantBlock.goToNextStage(main);
+            success = effectivePlantBlock.goToNextStage(performantPlants);
         }
         return new ScriptResult(success);
     }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCreatePlantBlocks.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationCreatePlantBlocks.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.scripting.operations.action;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.GrowthStageBlock;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -54,7 +54,7 @@ public class ScriptOperationCreatePlantBlocks extends ScriptOperation {
                     if (MetadataHelper.hasPlantBlockMetadata(absoluteBlock) && !growthStageBlock.isReplacePlantBlock()) {
                         continue;
                     } else {
-                        BlockHelper.destroyPlantBlock(Main.getInstance(),absoluteBlock, false);
+                        BlockHelper.destroyPlantBlock(PerformantPlants.getInstance(),absoluteBlock, false);
                     }
                     if (!absoluteBlock.isEmpty() && !growthStageBlock.isReplaceVanillaBlock()) {
                         continue;
@@ -74,7 +74,7 @@ public class ScriptOperationCreatePlantBlocks extends ScriptOperation {
                 // set parent to be effectivePlantBlock
                 newPlantBlock.setParentLocation(effectivePlantBlock.getLocation());
                 // add plant block via plantManager
-                Main.getInstance().getPlantManager().addPlantBlock(newPlantBlock);
+                PerformantPlants.getInstance().getPlantManager().addPlantBlock(newPlantBlock);
                 // if has childOf set, add to blocksAdded
                 if (growthStageBlock.hasChildOf()) {
                     blocksWithGuardiansAdded.put(growthStageBlock, newPlantBlock);
@@ -88,7 +88,7 @@ public class ScriptOperationCreatePlantBlocks extends ScriptOperation {
             // get guardian location
             BlockLocation guardianLocation = effectivePlantBlock.getLocation().getLocationFromRelative(growthStageBlock.getChildOf());
             // get guardian block
-            PlantBlock guardianBlock = Main.getInstance().getPlantManager().getPlantBlock(guardianLocation);
+            PlantBlock guardianBlock = PerformantPlants.getInstance().getPlantManager().getPlantBlock(guardianLocation);
             if (guardianBlock != null) {
                 // add guardian to plant block
                 newPlantBlock.setGuardianLocation(guardianLocation);

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationScheduleTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationScheduleTask.java
@@ -1,0 +1,97 @@
+package me.kosinkadink.performantplants.scripting.operations.action;
+
+import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.*;
+import me.kosinkadink.performantplants.tasks.PlantTask;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptOperationScheduleTask extends ScriptOperation {
+
+    private final String plantId;
+    private final String taskConfigId;
+
+    public ScriptOperationScheduleTask(String plantId, String taskConfigId, ScriptBlock delay, ScriptBlock currentPlayer,
+                                       ScriptBlock currentBlock, ScriptBlock playerId) {
+        super(delay, currentPlayer, currentBlock, playerId);
+        this.plantId = plantId;
+        this.taskConfigId = taskConfigId;
+    }
+
+    public ScriptBlock getDelay() {
+        return inputs[0];
+    }
+
+    public ScriptBlock getCurrentPlayer() {
+        return inputs[1];
+    }
+
+    public ScriptBlock getCurrentBlock() {
+        return inputs[2];
+    }
+
+    public ScriptBlock getPlayerId() {
+        return inputs[3];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        PlantTask plantTask = new PlantTask(plantId, taskConfigId);
+        // set delay
+        long delay = getDelay().loadValue(plantBlock, player).getLongValue();
+        if (delay < 0) {
+            delay = 0;
+        }
+        plantTask.setDelay(delay);
+        // set offline player
+        String playerId = getPlayerId().loadValue(plantBlock, player).getStringValue();
+        boolean currentPlayer = getCurrentPlayer().loadValue(plantBlock, player).getBooleanValue();
+        OfflinePlayer offlinePlayer = null;
+        if (!playerId.isEmpty()) {
+            UUID playerUUID;
+            try {
+                playerUUID = UUID.fromString(playerId);
+                offlinePlayer = Main.getInstance().getServer().getOfflinePlayer(playerUUID);
+            } catch (IllegalArgumentException e) {
+                // assume the string is a direct name
+                offlinePlayer = Main.getInstance().getServer().getOfflinePlayer(playerId);
+            }
+        } else if (currentPlayer) {
+            offlinePlayer = player;
+        }
+        plantTask.setOfflinePlayer(offlinePlayer);
+        // set block location
+        boolean currentBlock = getCurrentBlock().loadValue(plantBlock, player).getBooleanValue();
+        if (currentBlock && plantBlock != null) {
+            plantTask.setBlockLocation(plantBlock.getLocation());
+        }
+        // attempt to schedule task and return result
+        if (Main.getInstance().getTaskManager().scheduleTask(plantTask)) {
+            return new ScriptResult(plantTask.getTaskId().toString());
+        }
+        return ScriptResult.EMPTY;
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.STRING;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.ACTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationScheduleTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/action/ScriptOperationScheduleTask.java
@@ -1,15 +1,12 @@
 package me.kosinkadink.performantplants.scripting.operations.action;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.plants.Plant;
 import me.kosinkadink.performantplants.scripting.*;
 import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
 import me.kosinkadink.performantplants.tasks.PlantTask;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-
-import java.util.UUID;
 
 public class ScriptOperationScheduleTask extends ScriptOperation {
 
@@ -46,7 +43,7 @@ public class ScriptOperationScheduleTask extends ScriptOperation {
 
     @Override
     public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
-        Plant plant = Main.getInstance().getPlantTypeManager().getPlantById(plantId);
+        Plant plant = PerformantPlants.getInstance().getPlantTypeManager().getPlantById(plantId);
         if (plant == null) {
             return ScriptResult.EMPTY;
         }
@@ -68,7 +65,7 @@ public class ScriptOperationScheduleTask extends ScriptOperation {
             return ScriptResult.EMPTY;
         }
         // attempt to schedule task and return result
-        if (Main.getInstance().getTaskManager().scheduleTask(plantTask)) {
+        if (PerformantPlants.getInstance().getTaskManager().scheduleTask(plantTask)) {
             return new ScriptResult(plantTask.getTaskId().toString());
         }
         return ScriptResult.EMPTY;

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationContainsScopeParameter.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationContainsScopeParameter.java
@@ -1,0 +1,57 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.*;
+import me.kosinkadink.performantplants.util.ScriptHelper;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationContainsScopeParameter extends ScriptOperation {
+
+    public ScriptOperationContainsScopeParameter(ScriptBlock plantId, ScriptBlock scope, ScriptBlock parameter) {
+        super(plantId, scope, parameter);
+    }
+
+    public ScriptBlock getPlantId() {
+        return inputs[0];
+    }
+
+    public ScriptBlock getScope() {
+        return inputs[1];
+    }
+
+    public ScriptBlock getParameter() {
+        return inputs[2];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        String plantId = getPlantId().loadValue(plantBlock, player).getStringValue();
+        String scope = getScope().loadValue(plantBlock, player).getStringValue();
+        String parameter = getParameter().loadValue(plantBlock, player).getStringValue();
+        return new ScriptResult(PerformantPlants.getInstance().getPlantTypeManager().containsScopeParameter(plantId, scope, parameter));
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.BOOLEAN;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+        // script blocks must be type STRING
+        if (!ScriptHelper.isString(getPlantId()) || !ScriptHelper.isString(getScope()) || !ScriptHelper.isString(getParameter())) {
+            throw new IllegalArgumentException("PlantId, scope, and parameter must be ScriptType STRING");
+        }
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationGetValueScopeParameter.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationGetValueScopeParameter.java
@@ -1,0 +1,75 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.*;
+import me.kosinkadink.performantplants.util.ScriptHelper;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationGetValueScopeParameter extends ScriptOperation {
+
+    private final ScriptType expectedType;
+
+    public ScriptOperationGetValueScopeParameter(ScriptBlock plantId, ScriptBlock scope, ScriptBlock parameter, ScriptBlock variableName, ScriptType expectedType) {
+        super(plantId, scope, parameter, variableName);
+        if (!ScriptHelper.isSupportedType(expectedType)) {
+            throw new IllegalArgumentException("ExpectedType must be ScriptType BOOLEAN, STRING, LONG, or DOUBLE");
+        }
+        this.expectedType = expectedType;
+        setType();
+    }
+
+    public ScriptBlock getPlantId() {
+        return inputs[0];
+    }
+
+    public ScriptBlock getScope() {
+        return inputs[1];
+    }
+
+    public ScriptBlock getParameter() {
+        return inputs[2];
+    }
+
+    public ScriptBlock getVariableName() {
+        return inputs[3];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        String plantId = getPlantId().loadValue(plantBlock, player).getStringValue();
+        String scope = getScope().loadValue(plantBlock, player).getStringValue();
+        String parameter = getParameter().loadValue(plantBlock, player).getStringValue();
+        String variableName = getVariableName().loadValue(plantBlock, player).getStringValue();
+        Object value = PerformantPlants.getInstance().getPlantTypeManager().getVariable(plantId, scope, parameter, variableName);
+        // if got null, return default value of expected type
+        if (value == null) {
+            return ScriptResult.getDefaultOfType(expectedType);
+        }
+        return new ScriptResult(value);
+    }
+
+    @Override
+    protected void setType() {
+        type = expectedType;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+        // script blocks (except for value) must be type STRING
+        if (!ScriptHelper.isString(getPlantId()) || !ScriptHelper.isString(getScope())
+                || !ScriptHelper.isString(getParameter()) || !ScriptHelper.isString(getVariableName())) {
+            throw new IllegalArgumentException("PlantId, scope, parameter, and variableName must be ScriptType STRING");
+        }
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationIsBlockNull.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationIsBlockNull.java
@@ -1,0 +1,36 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.ScriptCategory;
+import me.kosinkadink.performantplants.scripting.ScriptOperation;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import me.kosinkadink.performantplants.scripting.ScriptType;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationIsBlockNull extends ScriptOperation {
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        return new ScriptResult(plantBlock == null);
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.BOOLEAN;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationIsPlayerNull.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationIsPlayerNull.java
@@ -1,0 +1,36 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.ScriptCategory;
+import me.kosinkadink.performantplants.scripting.ScriptOperation;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import me.kosinkadink.performantplants.scripting.ScriptType;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationIsPlayerNull extends ScriptOperation {
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        return new ScriptResult(player == null);
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.BOOLEAN;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationRemoveScopeParameter.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationRemoveScopeParameter.java
@@ -1,0 +1,57 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.*;
+import me.kosinkadink.performantplants.util.ScriptHelper;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationRemoveScopeParameter extends ScriptOperation {
+
+    public ScriptOperationRemoveScopeParameter(ScriptBlock plantId, ScriptBlock scope, ScriptBlock parameter) {
+        super(plantId, scope, parameter);
+    }
+
+    public ScriptBlock getPlantId() {
+        return inputs[0];
+    }
+
+    public ScriptBlock getScope() {
+        return inputs[1];
+    }
+
+    public ScriptBlock getParameter() {
+        return inputs[2];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        String plantId = getPlantId().loadValue(plantBlock, player).getStringValue();
+        String scope = getScope().loadValue(plantBlock, player).getStringValue();
+        String parameter = getParameter().loadValue(plantBlock, player).getStringValue();
+        return new ScriptResult(PerformantPlants.getInstance().getPlantTypeManager().removeScopeParameter(plantId, scope, parameter));
+    }
+
+    @Override
+    protected void setType() {
+        type = ScriptType.BOOLEAN;
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+        // script blocks must be type STRING
+        if (!ScriptHelper.isString(getPlantId()) || !ScriptHelper.isString(getScope()) || !ScriptHelper.isString(getParameter())) {
+            throw new IllegalArgumentException("PlantId, scope, and parameter must be ScriptType STRING");
+        }
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationSetValueScopeParameter.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/function/ScriptOperationSetValueScopeParameter.java
@@ -1,0 +1,71 @@
+package me.kosinkadink.performantplants.scripting.operations.function;
+
+import me.kosinkadink.performantplants.PerformantPlants;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.ScriptCategory;
+import me.kosinkadink.performantplants.scripting.ScriptOperation;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import me.kosinkadink.performantplants.util.ScriptHelper;
+import org.bukkit.entity.Player;
+
+public class ScriptOperationSetValueScopeParameter extends ScriptOperation {
+
+    public ScriptOperationSetValueScopeParameter(ScriptBlock plantId, ScriptBlock scope, ScriptBlock parameter, ScriptBlock variableName, ScriptBlock value) {
+        super(plantId, scope, parameter, variableName, value);
+    }
+
+    public ScriptBlock getPlantId() {
+        return inputs[0];
+    }
+
+    public ScriptBlock getScope() {
+        return inputs[1];
+    }
+
+    public ScriptBlock getParameter() {
+        return inputs[2];
+    }
+
+    public ScriptBlock getVariableName() {
+        return inputs[3];
+    }
+
+    public ScriptBlock getValue() {
+        return inputs[4];
+    }
+
+    @Override
+    public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
+        String plantId = getPlantId().loadValue(plantBlock, player).getStringValue();
+        String scope = getScope().loadValue(plantBlock, player).getStringValue();
+        String parameter = getParameter().loadValue(plantBlock, player).getStringValue();
+        String variableName = getVariableName().loadValue(plantBlock, player).getStringValue();
+        Object value = getValue().loadValue(plantBlock, player).getValue();
+        return new ScriptResult(PerformantPlants.getInstance().getPlantTypeManager().updateVariable(plantId, scope, parameter, variableName, value));
+    }
+
+    @Override
+    protected void setType() {
+        type = getValue().getType();
+    }
+
+    @Override
+    protected void validateInputs() throws IllegalArgumentException {
+        // script blocks (except for value) must be type STRING
+        if (!ScriptHelper.isString(getPlantId()) || !ScriptHelper.isString(getScope())
+                || !ScriptHelper.isString(getParameter()) || !ScriptHelper.isString(getVariableName())) {
+            throw new IllegalArgumentException("PlantId, scope, parameter, and variableName must be ScriptType STRING");
+        }
+    }
+
+    @Override
+    public boolean shouldOptimize() {
+        return false;
+    }
+
+    @Override
+    public ScriptCategory getCategory() {
+        return ScriptCategory.FUNCTION;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/random/ScriptOperationRandomDouble.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/random/ScriptOperationRandomDouble.java
@@ -19,12 +19,7 @@ public class ScriptOperationRandomDouble extends ScriptOperationBinary {
     public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
         ScriptResult leftInstance = getLeft().loadValue(plantBlock, player);
         ScriptResult rightInstance = getRight().loadValue(plantBlock, player);
-        // if left value is greater or equal to right value,
-        // prevent error from occurring and just return 0.0
-        if (leftInstance.getDoubleValue() >= rightInstance.getDoubleValue()) {
-            return new ScriptResult(0.0);
-        }
-        // otherwise go ahead and perform the random generation
+        // perform the random generation
         return new ScriptResult(RandomHelper.generateRandomDoubleInRange(
                 leftInstance.getDoubleValue(), rightInstance.getDoubleValue()
         ));

--- a/src/main/java/me/kosinkadink/performantplants/scripting/operations/random/ScriptOperationRandomLong.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/operations/random/ScriptOperationRandomLong.java
@@ -19,12 +19,7 @@ public class ScriptOperationRandomLong extends ScriptOperationBinary {
     public ScriptResult perform(PlantBlock plantBlock, Player player) throws IllegalArgumentException {
         ScriptResult leftInstance = getLeft().loadValue(plantBlock, player);
         ScriptResult rightInstance = getRight().loadValue(plantBlock, player);
-        // if left value is greater or equal to right value,
-        // prevent error from occurring and just return 0L
-        if (leftInstance.getLongValue() >= rightInstance.getLongValue()) {
-            return new ScriptResult(0L);
-        }
-        // otherwise go ahead and perform the random generation
+        // perform the random generation
         return new ScriptResult(RandomHelper.generateRandomLongInRange(
                 leftInstance.getLongValue(), rightInstance.getLongValue()
         ));

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.scripting.storage;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.hooks.PlantHook;
 import me.kosinkadink.performantplants.scripting.ScriptBlock;
@@ -68,7 +68,7 @@ public class ScriptTask {
             if (!playerIdValue.isEmpty()) {
                 try {
                     UUID playerUUID = UUID.fromString(playerIdValue);
-                    offlinePlayer = Main.getInstance().getServer().getOfflinePlayer(playerUUID);
+                    offlinePlayer = PerformantPlants.getInstance().getServer().getOfflinePlayer(playerUUID);
                 } catch (IllegalArgumentException e) {
                     return null;
                 }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
@@ -1,0 +1,121 @@
+package me.kosinkadink.performantplants.scripting.storage;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import me.kosinkadink.performantplants.tasks.PlantTask;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptTask {
+
+    private final String plantId;
+    private final String taskConfigId;
+
+    private ScriptBlock taskScriptBlock;
+    private ScriptBlock delay = ScriptResult.ZERO;
+    private ScriptBlock currentPlayer = ScriptResult.TRUE;
+    private ScriptBlock currentBlock = ScriptResult.TRUE;
+    private ScriptBlock playerId = ScriptResult.EMPTY;
+    // TODO: add hooks
+
+
+    public ScriptTask(String plantId, String taskConfigId) {
+        this.plantId = plantId;
+        this.taskConfigId = taskConfigId;
+    }
+
+    public PlantTask createPlantTask(Player player, PlantBlock plantBlock) {
+        PlantTask plantTask = new PlantTask(plantId, taskConfigId);
+        // set delay
+        plantTask.setDelay(getDelayValue(player, plantBlock));
+        // set current block location, if true
+        if (getCurrentBlockValue(player, plantBlock)) {
+            plantTask.setBlockLocation(plantBlock.getLocation());
+        }
+        // if playerId explicitly set, try to get it
+        if (playerId != ScriptResult.EMPTY) {
+            OfflinePlayer offlinePlayer;
+            String playerIdValue = getPlayerIdValue(player, plantBlock);
+            try {
+                UUID playerUUID = UUID.fromString(playerIdValue);
+                offlinePlayer = Bukkit.getOfflinePlayer(playerUUID);
+            } catch (IllegalArgumentException e) {
+                offlinePlayer = Bukkit.getOfflinePlayer(playerIdValue);
+            }
+            plantTask.setOfflinePlayer(offlinePlayer);
+        }
+        // otherwise, use current player
+        else if (getCurrentPlayerValue(player, plantBlock)) {
+            plantTask.setOfflinePlayer(player);
+        }
+        return plantTask;
+    }
+
+    public String getPlantId() {
+        return plantId;
+    }
+
+    public String getTaskConfigId() {
+        return taskConfigId;
+    }
+
+    public ScriptBlock getTaskScriptBlock() {
+        return taskScriptBlock;
+    }
+
+    public void setTaskScriptBlock(ScriptBlock taskScriptBlock) {
+        this.taskScriptBlock = taskScriptBlock;
+    }
+
+    public ScriptBlock getDelay() {
+        return delay;
+    }
+
+    public long getDelayValue(Player player, PlantBlock plantBlock) {
+        return delay.loadValue(plantBlock, player).getLongValue();
+    }
+
+    public void setDelay(ScriptBlock delay) {
+        this.delay = delay;
+    }
+
+    public ScriptBlock getCurrentPlayer() {
+        return currentPlayer;
+    }
+
+    public boolean getCurrentPlayerValue(Player player, PlantBlock plantBlock) {
+        return currentPlayer.loadValue(plantBlock, player).getBooleanValue();
+    }
+
+    public void setCurrentPlayer(ScriptBlock currentPlayer) {
+        this.currentPlayer = currentPlayer;
+    }
+
+    public ScriptBlock getCurrentBlock() {
+        return currentBlock;
+    }
+
+    public boolean getCurrentBlockValue(Player player, PlantBlock plantBlock) {
+        return currentBlock.loadValue(plantBlock, player).getBooleanValue();
+    }
+
+    public void setCurrentBlock(ScriptBlock currentBlock) {
+        this.currentBlock = currentBlock;
+    }
+
+    public ScriptBlock getPlayerId() {
+        return playerId;
+    }
+
+    public String getPlayerIdValue(Player player, PlantBlock plantBlock) {
+        return playerId.loadValue(plantBlock, player).getStringValue();
+    }
+
+    public void setPlayerId(ScriptBlock playerId) {
+        this.playerId = playerId;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/ScriptTask.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ScriptTask {
 
@@ -25,6 +26,7 @@ public class ScriptTask {
     private ScriptBlock currentBlock = ScriptResult.TRUE;
     private ScriptBlock playerId = ScriptResult.EMPTY;
     private final ArrayList<ScriptHook> hooks = new ArrayList<>();
+    private final ConcurrentHashMap<String, ScriptHook> hookMap = new ConcurrentHashMap<>();
 
 
     public ScriptTask(String plantId, String taskConfigId) {
@@ -159,6 +161,21 @@ public class ScriptTask {
 
     public void addHook(ScriptHook scriptHook) {
         hooks.add(scriptHook);
+        if (!scriptHook.getHookConfigId().isEmpty()) {
+            hookMap.put(scriptHook.getHookConfigId(), scriptHook);
+        }
+    }
+
+    public ScriptHook getHook(String hookConfigId) {
+        return hookMap.get(hookConfigId);
+    }
+
+    public ScriptBlock getHookScriptBlock(String hookConfigId) {
+        ScriptHook hook = getHook(hookConfigId);
+        if (hook != null) {
+            return hook.getHookScriptBlock();
+        }
+        return null;
     }
 
     public ScriptBlock getAutostart() {

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHook.java
@@ -1,0 +1,24 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.hooks.PlantHook;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public abstract class ScriptHook {
+
+    protected final HookAction action;
+
+    public ScriptHook(HookAction action) {
+        this.action = action;
+    }
+
+    public HookAction getAction() {
+        return action;
+    }
+
+    public abstract PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock);
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHook.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHook.java
@@ -3,6 +3,7 @@ package me.kosinkadink.performantplants.scripting.storage.hooks;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.hooks.HookAction;
 import me.kosinkadink.performantplants.hooks.PlantHook;
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
@@ -11,12 +12,31 @@ public abstract class ScriptHook {
 
     protected final HookAction action;
 
+    protected String hookConfigId = "";
+    protected ScriptBlock hookScriptBlock;
+
     public ScriptHook(HookAction action) {
         this.action = action;
     }
 
     public HookAction getAction() {
         return action;
+    }
+
+    public String getHookConfigId() {
+        return hookConfigId;
+    }
+
+    public void setHookConfigId(String hookConfigId) {
+        this.hookConfigId = hookConfigId;
+    }
+
+    public ScriptBlock getHookScriptBlock() {
+        return hookScriptBlock;
+    }
+
+    public void setHookScriptBlock(ScriptBlock hookScriptBlock) {
+        this.hookScriptBlock = hookScriptBlock;
     }
 
     public abstract PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock);

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayer.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayer.java
@@ -1,0 +1,65 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.scripting.ScriptBlock;
+import me.kosinkadink.performantplants.scripting.ScriptResult;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public abstract class ScriptHookPlayer extends ScriptHook {
+
+    protected ScriptBlock currentPlayer = ScriptResult.TRUE;
+    protected ScriptBlock playerId = ScriptResult.EMPTY;
+
+    public ScriptHookPlayer(HookAction action) {
+        super(action);
+    }
+
+    public ScriptBlock getCurrentPlayer() {
+        return currentPlayer;
+    }
+
+    public boolean getCurrentPlayerValue(Player player, PlantBlock plantBlock) {
+        return currentPlayer.loadValue(plantBlock, player).getBooleanValue();
+    }
+
+    public void setCurrentPlayer(ScriptBlock currentPlayer) {
+        this.currentPlayer = currentPlayer;
+    }
+
+    public ScriptBlock getPlayerId() {
+        return playerId;
+    }
+
+    public String getPlayerIdValue(Player player, PlantBlock plantBlock) {
+        return playerId.loadValue(plantBlock, player).getStringValue();
+    }
+
+    public void setPlayerId(ScriptBlock playerId) {
+        this.playerId = playerId;
+    }
+
+    protected OfflinePlayer createOfflinePlayer(Player player, PlantBlock plantBlock) {
+        OfflinePlayer offlinePlayer = null;
+        // if playerId explicitly set, try to get it
+        if (playerId != ScriptResult.EMPTY) {
+            String playerIdValue = getPlayerIdValue(player, plantBlock);
+            try {
+                UUID playerUUID = UUID.fromString(playerIdValue);
+                offlinePlayer = Bukkit.getOfflinePlayer(playerUUID);
+            } catch (IllegalArgumentException e) {
+                offlinePlayer = Bukkit.getOfflinePlayer(playerIdValue);
+            }
+        }
+        // otherwise, use current player
+        else if (getCurrentPlayerValue(player, plantBlock)) {
+            offlinePlayer = player;
+        }
+        return offlinePlayer;
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerAlive.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerAlive.java
@@ -1,0 +1,21 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.hooks.PlantHook;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerAlive;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptHookPlayerAlive extends ScriptHookPlayer {
+
+    public ScriptHookPlayerAlive(HookAction action) {
+        super(action);
+    }
+
+    @Override
+    public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
+        return new PlantHookPlayerAlive(taskId, action, createOfflinePlayer(player, plantBlock));
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerAlive.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerAlive.java
@@ -16,6 +16,6 @@ public class ScriptHookPlayerAlive extends ScriptHookPlayer {
 
     @Override
     public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
-        return new PlantHookPlayerAlive(taskId, action, createOfflinePlayer(player, plantBlock));
+        return new PlantHookPlayerAlive(taskId, action, hookConfigId, createOfflinePlayer(player, plantBlock));
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerDead.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerDead.java
@@ -1,0 +1,21 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.hooks.PlantHook;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerDead;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptHookPlayerDead extends ScriptHookPlayer {
+
+    public ScriptHookPlayerDead(HookAction action) {
+        super(action);
+    }
+
+    @Override
+    public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
+        return new PlantHookPlayerDead(taskId, action, createOfflinePlayer(player, plantBlock));
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerDead.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerDead.java
@@ -16,6 +16,6 @@ public class ScriptHookPlayerDead extends ScriptHookPlayer {
 
     @Override
     public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
-        return new PlantHookPlayerDead(taskId, action, createOfflinePlayer(player, plantBlock));
+        return new PlantHookPlayerDead(taskId, action, hookConfigId, createOfflinePlayer(player, plantBlock));
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOffline.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOffline.java
@@ -3,7 +3,6 @@ package me.kosinkadink.performantplants.scripting.storage.hooks;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.hooks.HookAction;
 import me.kosinkadink.performantplants.hooks.PlantHook;
-import me.kosinkadink.performantplants.hooks.PlantHookPlayerAlive;
 import me.kosinkadink.performantplants.hooks.PlantHookPlayerOffline;
 import org.bukkit.entity.Player;
 
@@ -17,6 +16,6 @@ public class ScriptHookPlayerOffline extends ScriptHookPlayer {
 
     @Override
     public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
-        return new PlantHookPlayerOffline(taskId, action, createOfflinePlayer(player, plantBlock));
+        return new PlantHookPlayerOffline(taskId, action, hookConfigId, createOfflinePlayer(player, plantBlock));
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOffline.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOffline.java
@@ -1,0 +1,22 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.hooks.PlantHook;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerAlive;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerOffline;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptHookPlayerOffline extends ScriptHookPlayer {
+
+    public ScriptHookPlayerOffline(HookAction action) {
+        super(action);
+    }
+
+    @Override
+    public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
+        return new PlantHookPlayerOffline(taskId, action, createOfflinePlayer(player, plantBlock));
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOnline.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOnline.java
@@ -3,7 +3,6 @@ package me.kosinkadink.performantplants.scripting.storage.hooks;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.hooks.HookAction;
 import me.kosinkadink.performantplants.hooks.PlantHook;
-import me.kosinkadink.performantplants.hooks.PlantHookPlayerAlive;
 import me.kosinkadink.performantplants.hooks.PlantHookPlayerOnline;
 import org.bukkit.entity.Player;
 
@@ -17,6 +16,6 @@ public class ScriptHookPlayerOnline extends ScriptHookPlayer {
 
     @Override
     public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
-        return new PlantHookPlayerOnline(taskId, action, createOfflinePlayer(player, plantBlock));
+        return new PlantHookPlayerOnline(taskId, action, hookConfigId, createOfflinePlayer(player, plantBlock));
     }
 }

--- a/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOnline.java
+++ b/src/main/java/me/kosinkadink/performantplants/scripting/storage/hooks/ScriptHookPlayerOnline.java
@@ -1,0 +1,22 @@
+package me.kosinkadink.performantplants.scripting.storage.hooks;
+
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.hooks.HookAction;
+import me.kosinkadink.performantplants.hooks.PlantHook;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerAlive;
+import me.kosinkadink.performantplants.hooks.PlantHookPlayerOnline;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+public class ScriptHookPlayerOnline extends ScriptHookPlayer {
+
+    public ScriptHookPlayerOnline(HookAction action) {
+        super(action);
+    }
+
+    @Override
+    public PlantHook createPlantHook(UUID taskId, Player player, PlantBlock plantBlock) {
+        return new PlantHookPlayerOnline(taskId, action, createOfflinePlayer(player, plantBlock));
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/settings/ItemSettings.java
+++ b/src/main/java/me/kosinkadink/performantplants/settings/ItemSettings.java
@@ -189,7 +189,8 @@ public class ItemSettings {
         // add item flags
 
         if (!itemFlags.isEmpty()) {
-            builder.addItemFlags((ItemFlag[]) itemFlags.toArray());
+            ItemFlag[] itemFlagsArray = new ItemFlag[itemFlags.size()];
+            builder.addItemFlags(itemFlags.toArray(itemFlagsArray));
         }
         // add custom model data
         if (getCustomModelData() != null) {

--- a/src/main/java/me/kosinkadink/performantplants/storage/PlantChunkStorage.java
+++ b/src/main/java/me/kosinkadink/performantplants/storage/PlantChunkStorage.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.storage;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.chunks.PlantChunk;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -14,20 +14,20 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class PlantChunkStorage {
 
-    private Main main;
+    private PerformantPlants performantPlants;
     private String world;
     private ConcurrentHashMap<ChunkLocation, PlantChunk> plantChunks = new ConcurrentHashMap<>();
     private HashSet<BlockLocation> blockLocationsToDelete = new HashSet<>();
 
-    public PlantChunkStorage(Main mainClass, String world) {
-        main = mainClass;
+    public PlantChunkStorage(PerformantPlants performantPlantsClass, String world) {
+        performantPlants = performantPlantsClass;
         this.world = world;
     }
 
     public void unloadAll() {
         for (PlantChunk plantChunk : plantChunks.values()) {
             if (plantChunk.isLoaded()) {
-                plantChunk.unload(main);
+                plantChunk.unload(performantPlants);
             }
         }
     }
@@ -48,7 +48,7 @@ public class PlantChunkStorage {
         // add plantBlock to plantChunk
         plantChunk.addPlantBlock(block);
         // add metadata to block
-        MetadataHelper.setPlantBlockMetadata(main, block);
+        MetadataHelper.setPlantBlockMetadata(performantPlants, block);
         // remove block from removal set
         removeBlockFromRemoval(block);
     }
@@ -64,8 +64,8 @@ public class PlantChunkStorage {
             // add block to removal set
             addBlockForRemoval(block);
             // remove metadata from block
-            MetadataHelper.removePlantBlockMetadata(main, block.getBlock());
-            if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Removed PlantBlock: " + block.toString()+ " from world: "
+            MetadataHelper.removePlantBlockMetadata(performantPlants, block.getBlock());
+            if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Removed PlantBlock: " + block.toString()+ " from world: "
                     + getWorldName()
             );
             // if no more plant blocks in plantChunk, remove plantChunk
@@ -99,7 +99,7 @@ public class PlantChunkStorage {
 
     public void addPlantChunk(PlantChunk chunk) {
         if (chunk.isChunkLoaded() && !chunk.isLoaded()) {
-            chunk.load(main);
+            chunk.load(performantPlants);
         }
         plantChunks.put(chunk.getLocation(), chunk);
         //if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Added PlantChunk: " + chunk.toString());
@@ -107,7 +107,7 @@ public class PlantChunkStorage {
 
     public void removePlantChunk(PlantChunk chunk) {
         plantChunks.remove(chunk.getLocation());
-        if (main.getConfigManager().getConfigSettings().isDebug()) main.getLogger().info("Removed PlantChunk: " + chunk.toString());
+        if (performantPlants.getConfigManager().getConfigSettings().isDebug()) performantPlants.getLogger().info("Removed PlantChunk: " + chunk.toString());
     }
 
     void addBlockForRemoval(PlantBlock block) {

--- a/src/main/java/me/kosinkadink/performantplants/storage/PlantDataStorage.java
+++ b/src/main/java/me/kosinkadink/performantplants/storage/PlantDataStorage.java
@@ -36,6 +36,14 @@ public class PlantDataStorage {
         return null;
     }
 
+    public boolean containsScopeParameter(String scope, String parameter) {
+        ScopedPlantData scopedPlantData = getScopedPlantData(scope);
+        if (scopedPlantData != null) {
+            return scopedPlantData.getPlantDataMap().containsKey(parameter);
+        }
+        return false;
+    }
+
     public boolean removeScopeParameter(String scope, String parameter) {
         ScopedPlantData scopedPlantData = getScopedPlantData(scope);
         if (scopedPlantData != null) {

--- a/src/main/java/me/kosinkadink/performantplants/storage/PlantDataStorage.java
+++ b/src/main/java/me/kosinkadink/performantplants/storage/PlantDataStorage.java
@@ -36,6 +36,17 @@ public class PlantDataStorage {
         return null;
     }
 
+    public boolean removeScopeParameter(String scope, String parameter) {
+        ScopedPlantData scopedPlantData = getScopedPlantData(scope);
+        if (scopedPlantData != null) {
+            // remove data for parameter and add to removal
+            scopedPlantData.removePlantData(parameter);
+            addScopeForRemoval(new ScopeParameterIdentifier(plantId, scope, parameter));
+            return true;
+        }
+        return false;
+    }
+
     public boolean updateVariable(String scope, String parameter, String variableName, Object value) {
         ScopedPlantData scopedPlantData = getScopedPlantData(scope);
         if (scopedPlantData != null) {

--- a/src/main/java/me/kosinkadink/performantplants/storage/PlantInteractStorage.java
+++ b/src/main/java/me/kosinkadink/performantplants/storage/PlantInteractStorage.java
@@ -1,7 +1,6 @@
 package me.kosinkadink.performantplants.storage;
 
-import me.kosinkadink.performantplants.Main;
-import me.kosinkadink.performantplants.builders.PlantItemBuilder;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.plants.PlantInteract;
 import me.kosinkadink.performantplants.util.ItemHelper;
 import org.bukkit.block.BlockFace;
@@ -37,7 +36,7 @@ public class PlantInteractStorage {
             if (plantInteract.isMatchMaterial() || plantInteract.isMatchEnchantments()) {
                 if (plantInteract.isMatchMaterial()) {
                     if (itemStack.getType() != plantInteract.getItemStack().getType() ||
-                            Main.getInstance().getPlantTypeManager().isPlantItemStack(itemStack)) {
+                            PerformantPlants.getInstance().getPlantTypeManager().isPlantItemStack(itemStack)) {
                         continue;
                     }
                 }

--- a/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.tasks;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.hooks.PlantHook;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -50,7 +50,7 @@ public class PlantTask {
 
     private void setupScriptTask() {
         // get task based on plant and task config id
-        Plant plant = Main.getInstance().getPlantTypeManager().getPlantById(plantId);
+        Plant plant = PerformantPlants.getInstance().getPlantTypeManager().getPlantById(plantId);
         if (plant != null) {
             ScriptTask scriptTask = plant.getScriptTask(taskConfigId);
             if (scriptTask != null) {
@@ -63,7 +63,7 @@ public class PlantTask {
         return scriptTask;
     }
 
-    public boolean startTask(Main main) {
+    public boolean startTask(PerformantPlants performantPlants) {
         // if task already exists, do nothing
         if (!isStartable()) {
             return false;
@@ -71,14 +71,14 @@ public class PlantTask {
         // set new start time
         taskStartTime = System.currentTimeMillis();
         // start script task
-        bukkitTask = Main.getInstance().getServer().getScheduler().runTaskLater(Main.getInstance(),
+        bukkitTask = PerformantPlants.getInstance().getServer().getScheduler().runTaskLater(PerformantPlants.getInstance(),
                 () -> {
                     try {
                         scriptTask.getTaskScriptBlock().loadValue(getPlantBlock(), PlayerHelper.getFreshPlayer(offlinePlayer));
                     } catch (Exception e) {
                         // do nothing
                     }
-                    Main.getInstance().getTaskManager().cancelTask(taskId.toString(), null);
+                    PerformantPlants.getInstance().getTaskManager().cancelTask(taskId.toString(), null);
                 }, delay);
         // mark not paused
         paused = false;
@@ -119,9 +119,9 @@ public class PlantTask {
         paused = initialPause;
     }
 
-    public void unfreezeTask(Main main) {
+    public void unfreezeTask(PerformantPlants performantPlants) {
         if (!isPaused()) {
-            startTask(main);
+            startTask(performantPlants);
         }
     }
 
@@ -156,7 +156,7 @@ public class PlantTask {
     public PlantBlock getPlantBlock() {
         PlantBlock plantBlock = null;
         if (blockLocation != null) {
-            plantBlock = Main.getInstance().getPlantManager().getPlantBlock(blockLocation);
+            plantBlock = PerformantPlants.getInstance().getPlantManager().getPlantBlock(blockLocation);
         }
         return plantBlock;
     }

--- a/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
@@ -192,6 +192,10 @@ public class PlantTask {
         return paused;
     }
 
+    public void setInitialPausedValue(boolean paused) {
+        this.paused = paused;
+    }
+
     public boolean isCancelled() {
         return cancelled;
     }

--- a/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
+++ b/src/main/java/me/kosinkadink/performantplants/tasks/PlantTask.java
@@ -1,0 +1,135 @@
+package me.kosinkadink.performantplants.tasks;
+
+import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.blocks.PlantBlock;
+import me.kosinkadink.performantplants.locations.BlockLocation;
+import me.kosinkadink.performantplants.plants.Plant;
+import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
+import me.kosinkadink.performantplants.util.TimeHelper;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.UUID;
+
+public class PlantTask {
+
+    private BukkitTask bukkitTask;
+    private long taskStartTime;
+    private boolean cancelled = false;
+    private boolean running = false;
+
+    private final UUID taskId;
+    private final String plantId;
+    private final String taskConfigId;
+
+    private OfflinePlayer offlinePlayer;
+    private BlockLocation blockLocation;
+    private long delay;
+
+    public PlantTask(String plantId, String taskConfigId) {
+        taskId = UUID.randomUUID();
+        this.plantId = plantId;
+        this.taskConfigId = taskConfigId;
+    }
+
+    public boolean startTask(Main main) {
+        // if task already exists, do nothing
+        if (isCancelled() || bukkitTask != null) {
+            return false;
+        }
+        // get task based on plant and task config id
+        Plant plant = Main.getInstance().getPlantTypeManager().getPlantById(plantId);
+        if (plant == null) {
+            return false;
+        }
+        ScriptTask scriptTask = plant.getScriptTask(taskConfigId);
+        if (scriptTask == null) {
+            return false;
+        }
+        // set new start time
+        taskStartTime = System.currentTimeMillis();
+        // start script task
+        bukkitTask = Main.getInstance().getServer().getScheduler().runTaskLater(Main.getInstance(),
+                () -> {
+                    PlantBlock plantBlock = null;
+                    if (blockLocation != null) {
+                        plantBlock = Main.getInstance().getPlantManager().getPlantBlock(blockLocation);
+                    }
+                    try {
+                        scriptTask.getTaskScriptBlock().loadValue(plantBlock, offlinePlayer.getPlayer());
+                    } catch (Exception e) {
+                        // do nothing
+                    }
+                    running = false;
+                    Main.getInstance().getTaskManager().cancelTask(taskId.toString());
+                }, delay);
+        running = true;
+        return true;
+    }
+
+    public void pauseTask() {
+        // try to cancel task
+        if (bukkitTask != null && running) {
+            bukkitTask.cancel();
+            running = false;
+            // figure out remaining time
+            long millisPassed = System.currentTimeMillis()-taskStartTime;
+            // subtract ticks passed from delay
+            delay -= TimeHelper.millisToTicks(millisPassed);
+            if (delay < 0) {
+                delay = 0;
+            }
+            // set task to null
+            bukkitTask = null;
+        }
+    }
+
+    public void cancelTask() {
+        pauseTask();
+        cancelled = true;
+    }
+
+    public UUID getTaskId() {
+        return taskId;
+    }
+
+    public String getPlantId() {
+        return plantId;
+    }
+
+    public String getTaskConfigId() {
+        return taskConfigId;
+    }
+
+    public OfflinePlayer getOfflinePlayer() {
+        return offlinePlayer;
+    }
+
+    public void setOfflinePlayer(OfflinePlayer offlinePlayer) {
+        this.offlinePlayer = offlinePlayer;
+    }
+
+    public BlockLocation getBlockLocation() {
+        return blockLocation;
+    }
+
+    public void setBlockLocation(BlockLocation blockLocation) {
+        this.blockLocation = blockLocation;
+    }
+
+    public long getDelay() {
+        return delay;
+    }
+
+    public void setDelay(long delay) {
+        this.delay = delay;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/src/main/java/me/kosinkadink/performantplants/util/BlockHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/BlockHelper.java
@@ -193,7 +193,8 @@ public class BlockHelper {
     public static boolean isInteractable(Block block) {
         return block.getType().isInteractable() &&
                 block.getType() != Material.PISTON_HEAD &&
-                !block.getType().toString().endsWith("STAIRS");
+                !block.getType().toString().endsWith("STAIRS") &&
+                !block.getType().toString().endsWith("FENCE");
     }
 
     public static Location getCenter(Block block) {

--- a/src/main/java/me/kosinkadink/performantplants/util/BlockHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/BlockHelper.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.util;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.GrowthStageBlock;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import me.kosinkadink.performantplants.locations.BlockLocation;
@@ -200,9 +200,9 @@ public class BlockHelper {
         return block.getLocation().add(0.5,0.5,0.5);
     }
 
-    public static void destroyPlantBlock(Main main, Block block, PlantBlock plantBlock, boolean drops) {
+    public static void destroyPlantBlock(PerformantPlants performantPlants, Block block, PlantBlock plantBlock, boolean drops) {
         block.setType(Material.AIR);
-        boolean removed = main.getPlantManager().removePlantBlock(plantBlock);
+        boolean removed = performantPlants.getPlantManager().removePlantBlock(plantBlock);
         // if block was not removed, don't do anything else
         if (!removed) {
             return;
@@ -215,29 +215,29 @@ public class BlockHelper {
         if (plantBlock.isBreakChildren()) {
             ArrayList<BlockLocation> childLocations = new ArrayList<>(plantBlock.getChildLocations());
             for (BlockLocation childLocation : childLocations) {
-                destroyPlantBlock(main, childLocation, drops);
+                destroyPlantBlock(performantPlants, childLocation, drops);
             }
         }
         // if block's parent should be removed, remove it
         if (plantBlock.isBreakParent()) {
             BlockLocation parentLocation = plantBlock.getParentLocation();
             if (parentLocation != null) {
-                destroyPlantBlock(main, parentLocation, drops);
+                destroyPlantBlock(performantPlants, parentLocation, drops);
             }
         }
     }
 
-    public static void destroyPlantBlock(Main main, Block block, boolean drops) {
-        PlantBlock plantBlock = main.getPlantManager().getPlantBlock(block);
+    public static void destroyPlantBlock(PerformantPlants performantPlants, Block block, boolean drops) {
+        PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(block);
         if (plantBlock != null) {
-            destroyPlantBlock(main, block, plantBlock, drops);
+            destroyPlantBlock(performantPlants, block, plantBlock, drops);
         }
     }
 
-    public static void destroyPlantBlock(Main main, BlockLocation blockLocation, boolean drops) {
-        PlantBlock plantBlock = main.getPlantManager().getPlantBlock(blockLocation);
+    public static void destroyPlantBlock(PerformantPlants performantPlants, BlockLocation blockLocation, boolean drops) {
+        PlantBlock plantBlock = performantPlants.getPlantManager().getPlantBlock(blockLocation);
         if (plantBlock != null) {
-            destroyPlantBlock(main, plantBlock.getBlock(), plantBlock, drops);
+            destroyPlantBlock(performantPlants, plantBlock.getBlock(), plantBlock, drops);
         }
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/util/ItemHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/ItemHelper.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.util;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -33,8 +33,8 @@ public class ItemHelper {
             return false;
         }
         if (base.getItemMeta() instanceof Damageable && getDamage(base) == 0) { // && !PlantItemBuilder.isPlantName(checked)) {
-            boolean isBasePlant = Main.getInstance().getPlantTypeManager().isPlantItemStack(base);
-            boolean isCheckedPlant = Main.getInstance().getPlantTypeManager().isPlantItemStack(checked);
+            boolean isBasePlant = PerformantPlants.getInstance().getPlantTypeManager().isPlantItemStack(base);
+            boolean isCheckedPlant = PerformantPlants.getInstance().getPlantTypeManager().isPlantItemStack(checked);
             if (isBasePlant != isCheckedPlant) {
                 return false;
             }

--- a/src/main/java/me/kosinkadink/performantplants/util/MetadataHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/MetadataHelper.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.util;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.blocks.PlantBlock;
 import org.bukkit.block.Block;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -11,15 +11,15 @@ import java.util.UUID;
 
 public class MetadataHelper {
 
-    public static void setPlantBlockMetadata(Main main, PlantBlock plantblock) {
+    public static void setPlantBlockMetadata(PerformantPlants performantPlants, PlantBlock plantblock) {
         plantblock.getBlock().setMetadata(
                 "performantplants-plant",
-                new FixedMetadataValue(main, plantblock.getPlantUUID().toString())
+                new FixedMetadataValue(performantPlants, plantblock.getPlantUUID().toString())
         );
     }
 
-    public static void removePlantBlockMetadata(Main main, Block block) {
-        block.removeMetadata("performantplants-plant", main);
+    public static void removePlantBlockMetadata(PerformantPlants performantPlants, Block block) {
+        block.removeMetadata("performantplants-plant", performantPlants);
     }
 
     public static boolean hasPlantBlockMetadata(Block block) {

--- a/src/main/java/me/kosinkadink/performantplants/util/PlaceholderHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/PlaceholderHelper.java
@@ -16,7 +16,7 @@ public class PlaceholderHelper {
             }
         }
         // replace plant variables
-        formatted = ScriptHelper.setVariables(plantBlock, formatted);
+        formatted = ScriptHelper.setVariables(plantBlock, player, formatted);
         // replace placeholders
         if (player != null) {
             if (Bukkit.getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {

--- a/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
@@ -1,5 +1,7 @@
 package me.kosinkadink.performantplants.util;
 
+import me.kosinkadink.performantplants.Main;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 
@@ -11,6 +13,20 @@ public class PlayerHelper {
 
     public static boolean isAlive(Player player) {
         return player.getHealth() > 0;
+    }
+
+    public static OfflinePlayer refreshOfflinePlayer(OfflinePlayer offlinePlayer) {
+        if (offlinePlayer == null) {
+            return null;
+        }
+        return Main.getInstance().getServer().getOfflinePlayer(offlinePlayer.getUniqueId());
+    }
+
+    public static Player getFreshPlayer(OfflinePlayer offlinePlayer) {
+        if (offlinePlayer != null) {
+            return refreshOfflinePlayer(offlinePlayer).getPlayer();
+        }
+        return null;
     }
 
     public static EquipmentSlot oppositeHand(EquipmentSlot hand) {

--- a/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.util;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
@@ -19,7 +19,7 @@ public class PlayerHelper {
         if (offlinePlayer == null) {
             return null;
         }
-        return Main.getInstance().getServer().getOfflinePlayer(offlinePlayer.getUniqueId());
+        return PerformantPlants.getInstance().getServer().getOfflinePlayer(offlinePlayer.getUniqueId());
     }
 
     public static Player getFreshPlayer(OfflinePlayer offlinePlayer) {

--- a/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/PlayerHelper.java
@@ -9,6 +9,10 @@ public class PlayerHelper {
         return player.getFoodLevel() < 20;
     }
 
+    public static boolean isAlive(Player player) {
+        return player.getHealth() > 0;
+    }
+
     public static EquipmentSlot oppositeHand(EquipmentSlot hand) {
         if (hand == EquipmentSlot.HAND) {
             return EquipmentSlot.OFF_HAND;

--- a/src/main/java/me/kosinkadink/performantplants/util/RandomHelper.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/RandomHelper.java
@@ -10,14 +10,32 @@ public class RandomHelper {
     }
 
     public static int generateRandomIntInRange(int min, int max) {
+        if (min == max) {
+            return min;
+        }
+        else if (min > max) {
+            return ThreadLocalRandom.current().nextInt(max, min);
+        }
         return ThreadLocalRandom.current().nextInt(min, max);
     }
 
     public static long generateRandomLongInRange(long min, long max) {
+        if (min == max) {
+            return min;
+        }
+        else if (min > max) {
+            return ThreadLocalRandom.current().nextLong(max, min);
+        }
         return ThreadLocalRandom.current().nextLong(min, max);
     }
 
     public static double generateRandomDoubleInRange(double min, double max) {
+        if (min == max) {
+            return min;
+        }
+        else if (min > max) {
+            return ThreadLocalRandom.current().nextDouble(max, min);
+        }
         return ThreadLocalRandom.current().nextDouble(min, max);
     }
 

--- a/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
@@ -1,0 +1,28 @@
+package me.kosinkadink.performantplants.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ScriptTaskLoader {
+    private final ArrayList<String> taskNames = new ArrayList<>();
+    private final HashMap<String, ArrayList<String>> taskDependencies = new HashMap<>();
+    private final ArrayList<String> failedTasks = new ArrayList<>();
+
+    public ScriptTaskLoader() {}
+
+    public void addTaskName(String name) {
+        taskNames.add(name);
+    }
+
+    public void addTaskDependency(String name, String dependency) {
+        if (taskDependencies.containsKey(name)) {
+            ArrayList<String> dependencies = taskDependencies.get(name);
+            dependencies.add(dependency);
+        } else {
+            ArrayList<String> dependencies = new ArrayList<>();
+            dependencies.add(dependency);
+            taskDependencies.put(name, dependencies);
+        }
+    }
+
+}

--- a/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
@@ -1,6 +1,6 @@
 package me.kosinkadink.performantplants.util;
 
-import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.PerformantPlants;
 import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 public class ScriptTaskLoader {
-    Main main;
+    PerformantPlants performantPlants;
 
     private final HashSet<String> taskNames = new HashSet<>();
     private final HashMap<String, ArrayList<String>> taskDependencies = new HashMap<>();
@@ -19,8 +19,8 @@ public class ScriptTaskLoader {
 
     private final HashMap<String, ScriptTask> taskHashMap = new HashMap<>();
 
-    public ScriptTaskLoader(Main main) {
-        this.main = main;
+    public ScriptTaskLoader(PerformantPlants performantPlants) {
+        this.performantPlants = performantPlants;
     }
 
     public void addTaskName(String name) {
@@ -40,7 +40,7 @@ public class ScriptTaskLoader {
             for (String failedTask : failedTasks) {
                 ArrayList<String> dependencies = taskDependencies.get(failedTask);
                 if (dependencies != null && !dependencies.isEmpty()) {
-                    main.getLogger().warning(String.format("Task '%s' failed to load, so all tasks depending on it (%s) " +
+                    performantPlants.getLogger().warning(String.format("Task '%s' failed to load, so all tasks depending on it (%s) " +
                             "will be unloaded in section %s",
                             failedTask, dependencies.toString(), section.getCurrentPath()));
                     // remove dependent tasks from map

--- a/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/ScriptTaskLoader.java
@@ -1,17 +1,57 @@
 package me.kosinkadink.performantplants.util;
 
+import me.kosinkadink.performantplants.Main;
+import me.kosinkadink.performantplants.scripting.storage.ScriptTask;
+import org.bukkit.configuration.ConfigurationSection;
+
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 
 public class ScriptTaskLoader {
-    private final ArrayList<String> taskNames = new ArrayList<>();
+    Main main;
+
+    private final HashSet<String> taskNames = new HashSet<>();
     private final HashMap<String, ArrayList<String>> taskDependencies = new HashMap<>();
     private final ArrayList<String> failedTasks = new ArrayList<>();
 
-    public ScriptTaskLoader() {}
+    private String currentTask = "";
+
+    private final HashMap<String, ScriptTask> taskHashMap = new HashMap<>();
+
+    public ScriptTaskLoader(Main main) {
+        this.main = main;
+    }
 
     public void addTaskName(String name) {
         taskNames.add(name);
+    }
+
+    public boolean isTask(String name) {
+        return taskNames.contains(name);
+    }
+
+    public void addTask(String taskId, ScriptTask scriptTask) {
+        taskHashMap.put(taskId, scriptTask);
+    }
+
+    public HashMap<String, ScriptTask> processTasksAndReturnMap(ConfigurationSection section) {
+        if (!failedTasks.isEmpty()) {
+            for (String failedTask : failedTasks) {
+                ArrayList<String> dependencies = taskDependencies.get(failedTask);
+                if (dependencies != null && !dependencies.isEmpty()) {
+                    main.getLogger().warning(String.format("Task '%s' failed to load, so all tasks depending on it (%s) " +
+                            "will be unloaded in section %s",
+                            failedTask, dependencies.toString(), section.getCurrentPath()));
+                    // remove dependent tasks from map
+                    for (String dependency : dependencies) {
+                        taskHashMap.remove(dependency);
+                    }
+                }
+                taskHashMap.remove(failedTask);
+            }
+        }
+        return taskHashMap;
     }
 
     public void addTaskDependency(String name, String dependency) {
@@ -25,4 +65,17 @@ public class ScriptTaskLoader {
         }
     }
 
+    public void addFailedTask(String name) {
+        failedTasks.add(name);
+        // remove from task names
+        taskNames.remove(name);
+    }
+
+    public String getCurrentTask() {
+        return currentTask;
+    }
+
+    public void setCurrentTask(String currentTask) {
+        this.currentTask = currentTask;
+    }
 }

--- a/src/main/java/me/kosinkadink/performantplants/util/TaskAndHooksHolder.java
+++ b/src/main/java/me/kosinkadink/performantplants/util/TaskAndHooksHolder.java
@@ -1,0 +1,35 @@
+package me.kosinkadink.performantplants.util;
+
+import me.kosinkadink.performantplants.hooks.HookIdentifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TaskAndHooksHolder {
+
+    private final String taskUUID;
+    private List<HookIdentifier> hookIdentifiers = new ArrayList<>();
+
+    public TaskAndHooksHolder(String taskUUID, List<HookIdentifier> hookIdentifier) {
+        this.taskUUID = taskUUID;
+        this.hookIdentifiers = hookIdentifier;
+    }
+
+    public TaskAndHooksHolder(String taskUUID) {
+        this.taskUUID = taskUUID;
+    }
+
+    public TaskAndHooksHolder(List<HookIdentifier> hookIdentifiers) {
+        this.taskUUID = null;
+        this.hookIdentifiers = hookIdentifiers;
+    }
+
+    public String getTaskUUID() {
+        return taskUUID;
+    }
+
+    public List<HookIdentifier> getHookIdentifiers() {
+        return hookIdentifiers;
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: PerformantPlants
-version: 0.1.0
+version: 0.2.0
 api-version: '1.15'
 author: Kosinkadink
 main: me.kosinkadink.performantplants.PerformantPlants

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: PerformantPlants
 version: 0.1.0
 api-version: '1.15'
 author: Kosinkadink
-main: me.kosinkadink.performantplants.Main
+main: me.kosinkadink.performantplants.PerformantPlants
 softdepend: [Vault,PlaceholderAPI]
 commands:
   plants:

--- a/src/test/java/me/kosinkadink/performantplants/scripting/operations/TestScriptHelper.java
+++ b/src/test/java/me/kosinkadink/performantplants/scripting/operations/TestScriptHelper.java
@@ -85,7 +85,7 @@ public class TestScriptHelper {
         PlantBlock plantBlock = new PlantBlock(blockLocation, plant, false);
         plantBlock.setPlantData(new PlantData(jsonObject));
         // create expectations
-        String replaceMultipleDifferent = "There are $amount$ apples in $playerName$'s inventory at coords: ($_x$,$_y$,$_z$) in world: $_world$ with plant id: $_plantId$.";
+        String replaceMultipleDifferent = "There are $amount$ apples in $playerName$'s inventory at coords: ($_x$,$_y$,$_z$) in world: $_world$ with plant id: $_plant_id$.";
         String replaceMultipleDifferentExpected = "There are 24 apples in TESTPLAYER's inventory at coords: (25,50,75) in world: Test with plant id: testPlant.";
         assertEquals(replaceMultipleDifferentExpected, ScriptHelper.setVariables(plantBlock, replaceMultipleDifferent));
     }


### PR DESCRIPTION
Version bump to 0.2.0

Notable additions:
- Tasks and Hooks
- Global Scoped Variables, related Operations, and corresponding PAPI getter variable
- Support for zero-operand Operations
- More logging

Notable changes:
- Unary PlantScript Operations no longer use intermediate "input" parameter
- Rework of initializing PlantScript
- Main class changed to PerformantPlants
- Changed giveBlockDrops for on-break sections to be more intuitive

Notable bug fixes:
- Fixed fences counting as interactable blocks, causing vanilla block placement to not be cancelled when right-clicked with plant items
- Fixed unintuitive and downright erroneous behavior of RandomDouble and RandomLong Operations
- Fixed unintended Operation optimization
- Fixed ItemFlag setting for Items